### PR TITLE
1120: Remove duplicate readJson field on manager

### DIFF
--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -1021,8 +1021,6 @@ inline void requestRoutesManager(App& app)
                 if (!json_util::readJsonPatch(                            //
                         req, asyncResp->res,                              //
                         "DateTime", datetime,                             //
-                        "LocationIndicatorActive",
-                        locationIndicatorActive,                          //
                         "Links/ActiveSoftwareImage/@odata.id",
                         activeSoftwareImageOdataId,                       //
                         "LocationIndicatorActive",


### PR DESCRIPTION
The commit 1fba1cb [1][2] mistakelen left the duplicate readJson field on Managers patch.

This commit is to remove the duplicate.

```
inline void requestRoutesManager(App& app)
                 if (!json_util::readJsonPatch(                            //
                         req, asyncResp->res,                              //
                         "DateTime", datetime,                             //
-                        "LocationIndicatorActive",
-                        locationIndicatorActive,                          //
                         "Links/ActiveSoftwareImage/@odata.id",
                         activeSoftwareImageOdataId,                       //
                         "LocationIndicatorActive",
                         locationIndicatorActive,                          //
```

[1] https://github.com/ibm-openbmc/bmcweb/commit/1fba1cb67e282bd73aea3dfac833f22e0f67a08f
[2] https://github.com/ibm-openbmc/bmcweb/blob/1fba1cb67e282bd73aea3dfac833f22e0f67a08f/redfish-core/lib/managers.hpp#L1024-L1030