### PR TITLE
1120 Fix 204/304 incorrectly tracing CRITICAL message

### DIFF
--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -206,8 +206,8 @@ struct Response
         }
         response.content_length(*pSize);
 
-        if (is1XXReturn || result() == status::no_content ||
-            result() == status::not_modified)
+        if ((*pSize > 0) && (is1XXReturn || result() == status::no_content ||
+                             result() == status::not_modified))
         {
             BMCWEB_LOG_CRITICAL("{} Response content provided but code was "
                                 "no-content or not_modified, which aren't "

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -36,7 +36,6 @@
 
 #include <boost/asio/error.hpp>
 #include <boost/beast/http/field.hpp>
-#include <boost/beast/http/status.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/system/linux_error.hpp>
@@ -2970,8 +2969,6 @@ inline void handleComputerSystemPatch(
             return;
         }
     }
-
-    asyncResp->res.result(boost::beast::http::status::no_content);
 
     if (assetTag)
     {


### PR DESCRIPTION
Fix PATCH cases to return 200, 204 was previously being returned

curl -k -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/json" -X PATCH https://${bmc}/redfish/v1/Managers/bmc -d '{"Oem":{"IBM":{"USBCodeUpdateEnabled": false}}}' {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Success",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
curl -k -H "Content-Type: application/json" -d '{"PowerRestorePolicy":"LastState"}' -X PATCH https://${bmc}/redfish/v1/Systems/system {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Success",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
curl -k -H "Content-Type: application/json" -H "X-Auth-Token: $bmc_token" -X PATCH -d '{"LocationIndicatorActive":true}' https://${bmc}/redfish/v1/Managers/bmc {
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Success",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}