### PR TITLE
1120: Add missing fields to bmcweb_current_session_snapshot.json

### DIFF
--- a/include/persistent_data.hpp
+++ b/include/persistent_data.hpp
@@ -285,13 +285,17 @@ class ConfigFile
                 {"DeliveryRetryPolicy", subValue->retryPolicy},
                 {"Destination", subValue->destinationUrl},
                 {"EventFormatType", subValue->eventFormatType},
+                {"HeartbeatIntervalMinutes", subValue->hbIntervalMinutes},
                 {"HttpHeaders", std::move(headers)},
                 {"MessageIds", subValue->registryMsgIds},
+                {"MetricReportDefinitions", subValue->metricReportDefinitions},
+                {"OriginResources", subValue->originResources},
                 {"Protocol", subValue->protocol},
                 {"RegistryPrefixes", subValue->registryPrefixes},
                 {"ResourceTypes", subValue->resourceTypes},
+                {"SendHeartbeat", subValue->sendHeartbeat},
                 {"SubscriptionType", subValue->subscriptionType},
-                {"MetricReportDefinitions", subValue->metricReportDefinitions},
+                {"VerifyCertificate", subValue->verifyCertificate},
             });
         }
         persistentFile << data;


### PR DESCRIPTION
This commit is to add a few missing fields to
bmcweb_current_session_snapshot.json file which is generated by SIGUSR1.

- SendHeartbeat
- HeartbeatIntervalMinutes
- OriginResources
- VerifyCertificate

Tested:

- killall -s SIGUSR1 <bmcweb-pid> or run phosphor-debug-collector
- Check the content

```
cat bmcweb_current_session_snapshot.json | jq
...
 "subscriptions": [
    {
      "Context": "10.48.25.34",
      "DeliveryRetryPolicy": "TerminateAfterRetries",
      ...
      "HeartbeatIntervalMinutes": 3,
      ...
      "SendHeartbeat": true,
      ...
    }
```