### PR TITLE
1050: Fix http 400 error on Account Patch

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2567,12 +2567,8 @@ inline void
             return;
         }
 
-        // ConfigureSelf accounts can only modify their password
-        if (!json_util::readJsonPatch(req, asyncResp->res, "Password",
-                                      password))
-        {
-            return;
-        }
+        // NOTE: password was already obtained from the previous
+        // readJsonPatch().
     }
 
     // For accounts which have a Restricted Role, restrict which


### PR DESCRIPTION
The previous commit [1] is mistakenly calling readJsonPatch() twice for password field during AccountPatch. This causes http 400 error like

```
 redfishtool raw -r ${bmc} -u testReadOnly -p 0penBmc0  \
       -S Always PATCH /redfish/v1/AccountService/Accounts/testReadOnly \
       --data='{"Enabled":true, "Password": "0penBmc0"}'
   redfishtool: Transport: Response Error: status_code: 400 -- Bad Request
```

Tested:
- Create an account

```
curl -H "Content-type: application/json" -k -X POST https://${bmc}/redfish/v1/AccountService/Accounts \
              -d '{ "RoleId": "ReadOnly", "UserName": "testReadOnly", "Password":"0penBmc0", "Enabled":true}'
```

- Do Patch with Enabled or Password fields
```
redfishtool raw -r ${bmc} -u testReadOnly -p 0penBmc0  \
      -S Always PATCH /redfish/v1/AccountService/Accounts/testReadOnly \
     --data='{"Enabled":true}'

redfishtool raw -r ${bmc} -u testReadOnly -p 0penBmc0 \
     -S Always PATCH /redfish/v1/AccountService/Accounts/testReadOnly \
     --data='{"Enabled":true, "Password": "0penBmc0"}'
```

[1] https://github.com/ibm-openbmc/bmcweb/commit/eb824b1dc26dafacf1d8166e6a936fb7bf31dc40