### PR TITLE
systems: prevent internal error when mode/ips not available

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -1548,7 +1548,11 @@ inline void
     if (ec)
     {
         BMCWEB_LOG_ERROR("DBUS response error on PowerMode GetAll: {}", ec);
-        messages::internalError(asyncResp->res);
+        // Don't return an error on timeout (since it should eventually recover)
+        if(ec != boost::system::errc::timed_out)
+        {
+            messages::internalError(asyncResp->res);
+        }
         return;
     }
 
@@ -2064,7 +2068,11 @@ inline void
                 BMCWEB_LOG_ERROR(
                     "DBUS response error on Power.IdlePowerSaver GetSubTree {}",
                     ec);
-                messages::internalError(asyncResp->res);
+                // Don't return an error on timeout (since it should eventually recover)
+                if(ec != boost::system::errc::timed_out)
+                {
+                    messages::internalError(asyncResp->res);
+                }
                 return;
             }
             if (subtree.empty())


### PR DESCRIPTION
After BMC reboot it can sometimes take a while for the power mode or idle power status parameters to become available. This change will prevent returning an error when there is a timeout trying to read them. This will allow the other systems data to be returned.systems: prevent internal error when mode/ips not available

After BMC reboot it can sometimes take a while for the power mode or idle power status parameters to become available. This change will prevent returning an error when there is a timeout trying to read them. This will allow the other systems data to be returned.


Change-Id: I65f7e2f4ccf946ce108ca10f72cb81dd0e8a7fd2