### PR TITLE
1120: Fix PATCH of BiosSetting Attribute

### DIFF
--- a/redfish-core/lib/bios.hpp
+++ b/redfish-core/lib/bios.hpp
@@ -627,7 +627,7 @@ inline void handleBiosSettingsPatch(
                 {
                     const int64_t* attrValue =
                         attrItr.second.get_ptr<const int64_t*>();
-                    if (attrValue != nullptr)
+                    if (attrValue == nullptr)
                     {
                         BMCWEB_LOG_WARNING("The value must be of type int");
                         std::string val =
@@ -676,7 +676,7 @@ inline void handleBiosSettingsPatch(
                 {
                     const std::string* attrValue =
                         attrItr.second.get_ptr<const std::string*>();
-                    if (attrValue != nullptr)
+                    if (attrValue == nullptr)
                     {
                         BMCWEB_LOG_ERROR("The value must be of type String");
                         std::string val =
@@ -725,7 +725,7 @@ inline void handleBiosSettingsPatch(
                 {
                     const std::string* attrValue =
                         attrItr.second.get_ptr<const std::string*>();
-                    if (attrValue != nullptr)
+                    if (attrValue == nullptr)
                     {
                         BMCWEB_LOG_WARNING("The value must be of type string");
                         std::string val =
@@ -741,7 +741,7 @@ inline void handleBiosSettingsPatch(
                 {
                     const bool* attrValue =
                         attrItr.second.get_ptr<const bool*>();
-                    if (attrValue != nullptr)
+                    if (attrValue == nullptr)
                     {
                         BMCWEB_LOG_WARNING("The value must be of type bool");
                         std::string val =


### PR DESCRIPTION
The commit [1] incorrectly checks the bios table element type and causes the failure of setting like

```
curl -H "Content-Type:application/json" -k \
     -X PATCH https://${bmc}/redfish/v1/Systems/system/Bios/Settings \
      -d '{"Attributes":{"pvm_default_os_type":"AIX"}}'
{
  "pvm_default_os_type@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value '\"AIX\"' for the property pvm_default_os_type is not a type that the property can accept.",
      "MessageArgs": [
        "\"AIX\"",
        "pvm_default_os_type"
      ],
      "MessageId": "Base.1.19.PropertyValueTypeError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
```

[1] https://github.com/ibm-openbmc/bmcweb/commit/59186c90b106578bdb9d77b39d039483ac2b742a

Tested:
- Patch Bios setting