### PR TITLE
RBMC: Add compile option

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -10,6 +10,7 @@ feature_options = [
     'event-subscription',
     'experimental-redfish-dbus-log-subscription',
     'experimental-redfish-multi-computer-system',
+    'experimental-redfish-redundant-manager',
     'google-api',
     'host-serial-socket',
     'http-zstd',

--- a/meson.options
+++ b/meson.options
@@ -485,6 +485,18 @@ option(
     production environment, or where API stability is required.''',
 )
 
+# BMCWEB_EXPERIMENTAL_REDFISH_REDUNDANT_MANAGER
+option(
+    'experimental-redfish-redundant-manager',
+    type: 'feature',
+    value: 'disabled',
+    description: '''This is a temporary option flag for staging the
+                    support of redundant Manager. Do not enable in a production
+                    environment, or where API stability is required. Goal is to
+                    convert to non-experimental option once basic support is
+                    added.''',
+)
+
 # BMCWEB_HTTP2
 option(
     'http2',


### PR DESCRIPTION
Adding compile option for enabling redundant Manager support in bmcweb. This allows staging of the work.

Tested: Built enabled and disabled.

Note: Will create upstream commit to define this option as well once we agree on the naming of it.

Note: Will turn on by default for IBM huygens in the bmcweb_%.bbappend file once the option is merged:
```
EXTRA_OEMESON:append:huygens = " \
    -Dexperimental-redfish-redundant-manager=enabled \
"
```