### PR TITLE
RBMC: Get redundancy information for manager

### DIFF
--- a/docs/Redfish.md
+++ b/docs/Redfish.md
@@ -585,6 +585,10 @@ Fields common to all schemas
 - Oem
 - PartNumber
 - PowerState
+- Redundancy[]/MemberId
+- Redundancy[]/MinNumNeeded
+- Redundancy[]/Mode
+- Redundancy[]/RedundancySet[]
 - SerialNumber
 - ServiceEntryPointUUID
 - ServiceIdentification

--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "generated/enums/redundancy.hpp"
+#include "generated/enums/resource.hpp"
+#include "logging.hpp"
+#include "utils/dbus_utils.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <boost/url/format.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/message/native_types.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+
+#include <array>
+#include <cstddef>
+#include <format>
+#include <functional>
+#include <map>
+#include <memory>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace redfish
+{
+
+inline redundancy::RedundancyMode dBusRedundancyEnabledToRedfish(
+    const bool redundancyEnabled)
+{
+    if (redundancyEnabled)
+    {
+        return redundancy::RedundancyMode::Failover;
+    }
+
+    return redundancy::RedundancyMode::NotRedundant;
+}
+
+inline resource::State getRedundantState(bool failoversAllowed,
+                                         bool redundancyEnabled)
+{
+    if (!redundancyEnabled || !failoversAllowed)
+    {
+        return resource::State::Disabled;
+    }
+
+    return resource::State::Enabled;
+}
+
+inline void getRedundantData(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& managerId, nlohmann::json::object_t& redundantObject,
+    const boost::system::error_code& ec,
+    const dbus::utility::DBusPropertiesMap& propertiesList)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("D-Bus response error {}", ec);
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        BMCWEB_LOG_DEBUG("Can't get Redundancy properties");
+        return;
+    }
+
+    const bool* failoversAllowed = nullptr;
+    const bool* redundancyEnabled = nullptr;
+    const size_t* redundancyMinimum = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), propertiesList, "FailoversAllowed",
+        failoversAllowed, "RedundancyEnabled", redundancyEnabled,
+        "RedundancyMinimum", redundancyMinimum);
+
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    auto redundancyIt = asyncResp->res.jsonValue.find("Redundancy");
+
+    if (redundancyIt == asyncResp->res.jsonValue.end())
+    {
+        // Initialize the Redundancy array
+        BMCWEB_LOG_DEBUG("Initializing Redundancy array");
+        asyncResp->res.jsonValue["Redundancy"] = nlohmann::json::array_t();
+        asyncResp->res.jsonValue["Redundancy@odata.count"] = 0;
+        redundancyIt = asyncResp->res.jsonValue.find("Redundancy");
+    }
+
+    auto* redundancy = redundancyIt->get_ptr<nlohmann::json::array_t*>();
+    if (redundancy == nullptr)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    size_t objIdx = redundancy->size();
+
+    redundantObject["@odata.id"] = boost::urls::format(
+        "/redfish/v1/Managers/{}#/Redundancy/{}", managerId, objIdx);
+    redundantObject["MemberId"] = std::to_string(objIdx);
+    redundantObject["Name"] = "Manager Redundancy";
+
+    if (redundancyEnabled != nullptr)
+    {
+        redundantObject["Mode"] =
+            dBusRedundancyEnabledToRedfish(*redundancyEnabled);
+
+        if (failoversAllowed != nullptr)
+        {
+            redundantObject["Status"]["State"] =
+                getRedundantState(*failoversAllowed, *redundancyEnabled);
+        }
+    }
+
+    // TODO: Handle badpath for health
+    redundantObject["Status"]["Health"] = resource::Health::OK;
+
+    if (redundancyMinimum != nullptr)
+    {
+        redundantObject["MinNumNeeded"] = *redundancyMinimum;
+    }
+
+    redundancy->emplace_back(std::move(redundantObject));
+    asyncResp->res.jsonValue["Redundancy@odata.count"] = redundancy->size();
+}
+
+inline void handleRedundancySubTree(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& managerId, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreeResponse& subtree)
+{
+    if (ec)
+    {
+        if (ec == boost::system::errc::io_error)
+        {
+            BMCWEB_LOG_DEBUG("No redundant bmc objects");
+            return;
+        }
+
+        BMCWEB_LOG_ERROR("D-Bus response error on GetSubTree {}", ec);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    if (subtree.empty())
+    {
+        BMCWEB_LOG_DEBUG("No redundant bmc objects");
+        return;
+    }
+
+    nlohmann::json::object_t redundantObject;
+    nlohmann::json::array_t redundancySet;
+
+    // TODO: Redfish path name for sibling interface based on aggregation.
+    BMCWEB_LOG_DEBUG("Found {} redundant bmc D-Bus objects.", subtree.size());
+    nlohmann::json::object_t item;
+    item["@odata.id"] =
+        boost::urls::format("/redfish/v1/Managers/{}", managerId);
+    redundancySet.emplace_back(std::move(item));
+    redundantObject["RedundancySet@odata.count"] = redundancySet.size();
+    redundantObject["RedundancySet"] = std::move(redundancySet);
+
+    /* TODO: Will need to determine active BMC by looking at the redundancy
+     * state for each one. Need to use async gathering for that.
+     * May combine filling in the name in the set with gathering the
+     * other redundancy state information.
+     *
+     * For now, only look at state of this BMC which is always at bmc0
+     */
+    for (const auto& [path, services] : subtree)
+    {
+        sdbusplus::message::object_path managerPath(path);
+        if (managerPath.filename() == "bmc0")
+        {
+            // Expect a single service
+            if (services.size() != 1 || services[0].first.empty())
+            {
+                BMCWEB_LOG_ERROR("Unexpected Redundancy D-Bus subtree {}",
+                                 services.size());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            auto serviceName = services[0].first;
+
+            BMCWEB_LOG_DEBUG("Getting redundant properties for {} {}", path,
+                             serviceName);
+            dbus::utility::getAllProperties(
+                *crow::connections::systemBus, serviceName, path,
+                "xyz.openbmc_project.State.BMC.Redundancy",
+                std::bind_front(getRedundantData, asyncResp, managerId,
+                                redundantObject));
+            return;
+        }
+    }
+}
+
+inline void getManagerRedundancy(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& managerId)
+{
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.State.BMC.Redundancy"};
+    dbus::utility::getSubTree(
+        "/xyz/openbmc_project/state", 0, interfaces,
+        std::bind_front(handleRedundancySubTree, asyncResp, managerId));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -16,6 +16,7 @@
 #include "http_request.hpp"
 #include "led.hpp"
 #include "logging.hpp"
+#include "manager_redundancy.hpp"
 #include "oem/ibm/usb_code_update.hpp"
 #include "persistent_data.hpp"
 #include "query.hpp"
@@ -922,6 +923,11 @@ inline void handleManagerGet(
 
     getManagerObject(asyncResp, managerId,
                      std::bind_front(getManagerData, asyncResp));
+
+    if constexpr (BMCWEB_EXPERIMENTAL_REDFISH_REDUNDANT_MANAGER)
+    {
+        getManagerRedundancy(asyncResp, managerId);
+    }
 
     RedfishService::getInstance(app).handleSubRoute(req, asyncResp);
 }


### PR DESCRIPTION
TODO: Adding aggregated BMC to RedundancySet.

Tested:
 - Redfish Service Validator - passes checks on Redundancy
 - Redundancy included as part of Manager response when run on both the passive and active manager.

```
    /* Response looks same when run on either active or passive BMC */
    
    curl -s -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
    {
      "@odata.id": "/redfish/v1/Managers/bmc",
      "@odata.type": "#Manager.v1_15_0.Manager",
      ...
      "Redundancy": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc#/Redundancy/0",
          "MemberId": "0",
          "MinNumNeeded": 2,
          "Mode": "Failover",
          "Name": "Manager Redundancy",
          "RedundancySet": [
            {
              "@odata.id": "/redfish/v1/Managers/bmc"
            }
          ],
          "RedundancySet@odata.count": 1,
          "Status": {
            "Health": "OK",
            "State": "Enabled"
          }
        }
      ],
      "Redundancy@odata.count": 1,
      ...
```

    /* Response on both passive and active BMC after disabling redundancy
     * using rbmctool -s
     */
    ```
    curl -s -k -H "X-Auth-Token: $token" -X GET https://${bmc}/redfish/v1/Managers/bmc
    {
      "@odata.id": "/redfish/v1/Managers/bmc",
      "@odata.type": "#Manager.v1_15_0.Manager",
      ...
      "Redundancy": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc#/Redundancy/0",
          "MemberId": "0",
          "MinNumNeeded": 2,
          "Mode": "NotRedundant",
          "Name": "Manager Redundancy",
          "RedundancySet": [
            {
              "@odata.id": "/redfish/v1/Managers/bmc"
            }
          ],
          "RedundancySet@odata.count": 1,
          "Status": {
            "Health": "OK",
            "State": "Disabled"
          }
        }
      ],
      "Redundancy@odata.count": 1,
      ...
    ```
