### PR TITLE
IndicatorLED: Add compile option for deprecated property

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -31,6 +31,7 @@ feature_options = [
     'mutual-tls-auth',
     'redfish',
     'redfish-aggregation',
+    'redfish-allow-deprecated-indicatorled',
     'redfish-allow-deprecated-power-thermal',
     'redfish-allow-simple-update',
     'redfish-bmc-journal',

--- a/meson.options
+++ b/meson.options
@@ -326,6 +326,16 @@ option(
                     sensors in the SensorCollection.''',
 )
 
+# BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED
+option(
+    'redfish-allow-deprecated-indicatorled',
+    type: 'feature',
+    value: 'disabled',
+    description: '''Enable/disable the deprecated IndicatorLED property. The
+                    default condition is disabled. The code to enable this
+                    option will be removed by March 2026.''',
+)
+
 # BMCWEB_REDFISH_ALLOW_DEPRECATED_POWER_THERMAL
 option(
     'redfish-allow-deprecated-power-thermal',

--- a/redfish-core/include/utils/sensor_utils.hpp
+++ b/redfish-core/include/utils/sensor_utils.hpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
 
+#include "bmcweb_config.h"
+
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "generated/enums/resource.hpp"
@@ -523,7 +525,10 @@ inline void objectPropertiesToJson(
             unit = "/Reading"_json_pointer;
             sensorJson["ReadingUnits"] = thermal::ReadingUnits::RPM;
             sensorJson["@odata.type"] = "#Thermal.v1_3_0.Fan";
-            setLedState(sensorJson, inventoryItem);
+            if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+            {
+                setLedState(sensorJson, inventoryItem);
+            }
             forceToInt = true;
         }
         else if (sensorType == "fan_pwm")
@@ -531,7 +536,10 @@ inline void objectPropertiesToJson(
             unit = "/Reading"_json_pointer;
             sensorJson["ReadingUnits"] = thermal::ReadingUnits::Percent;
             sensorJson["@odata.type"] = "#Thermal.v1_3_0.Fan";
-            setLedState(sensorJson, inventoryItem);
+            if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+            {
+                setLedState(sensorJson, inventoryItem);
+            }
             forceToInt = true;
         }
         else if (sensorType == "voltage")

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -626,7 +626,10 @@ inline void handleChassisGetSubTree(
         {
             if (std::ranges::find(interfaces2, interface) != interfaces2.end())
             {
-                getIndicatorLedState(asyncResp);
+                if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+                {
+                    getIndicatorLedState(asyncResp);
+                }
                 getLocationIndicatorActive(asyncResp, objPath);
                 break;
             }
@@ -719,16 +722,23 @@ inline void handleChassisPatch(
         return;
     }
 
-    // TODO (Gunnar): Remove IndicatorLED after enough time has passed
     if (!locationIndicatorActive && !indicatorLed)
     {
         return; // delete this when we support more patch properties
     }
     if (indicatorLed)
     {
-        asyncResp->res.addHeader(
-            boost::beast::http::field::warning,
-            "299 - \"IndicatorLED is deprecated. Use LocationIndicatorActive instead.\"");
+        if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+        {
+            asyncResp->res.addHeader(
+                boost::beast::http::field::warning,
+                "299 - \"IndicatorLED is deprecated. Use LocationIndicatorActive instead.\"");
+        }
+        else
+        {
+            messages::propertyUnknown(asyncResp->res, "IndicatorLED");
+            return;
+        }
     }
 
     const std::string& chassisId = param;
@@ -798,16 +808,19 @@ inline void handleChassisPatch(
                                                   "LocationIndicatorActive");
                     }
                 }
-                if (indicatorLed)
+                if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
                 {
-                    if (indicatorChassis)
+                    if (indicatorLed)
                     {
-                        setIndicatorLedState(asyncResp, *indicatorLed);
-                    }
-                    else
-                    {
-                        messages::propertyUnknown(asyncResp->res,
-                                                  "IndicatorLED");
+                        if (indicatorChassis)
+                        {
+                            setIndicatorLedState(asyncResp, *indicatorLed);
+                        }
+                        else
+                        {
+                            messages::propertyUnknown(asyncResp->res,
+                                                      "IndicatorLED");
+                        }
                     }
                 }
                 return;

--- a/redfish-core/lib/sensors.hpp
+++ b/redfish-core/lib/sensors.hpp
@@ -1832,7 +1832,10 @@ inline nlohmann::json& getPowerSupply(nlohmann::json& powerSupplyArray,
     powerSupply["Model"] = inventoryItem.model;
     powerSupply["PartNumber"] = inventoryItem.partNumber;
     powerSupply["SerialNumber"] = inventoryItem.serialNumber;
-    sensor_utils::setLedState(powerSupply, &inventoryItem);
+    if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+    {
+        sensor_utils::setLedState(powerSupply, &inventoryItem);
+    }
 
     if (inventoryItem.powerSupplyEfficiencyPercent >= 0)
     {

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2817,8 +2817,11 @@ inline void handleComputerSystemGet(
             }
         });
 
-    // TODO (Gunnar): Remove IndicatorLED after enough time has passed
-    getIndicatorLedState(asyncResp);
+    if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+    {
+        getIndicatorLedState(asyncResp);
+    }
+
     getComputerSystem(asyncResp);
     getHostState(asyncResp);
     getBootProgress(asyncResp);
@@ -2970,6 +2973,15 @@ inline void handleComputerSystemPatch(
         }
     }
 
+    if constexpr (!BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
+    {
+        if (indicatorLed)
+        {
+            messages::propertyUnknown(asyncResp->res, "IndicatorLED");
+            return;
+        }
+    }
+
     if (assetTag)
     {
         setAssetTag(asyncResp, *assetTag);
@@ -3019,14 +3031,15 @@ inline void handleComputerSystemPatch(
             });
     }
 
-    // TODO (Gunnar): Remove IndicatorLED after enough time has
-    // passed
-    if (indicatorLed)
+    if constexpr (BMCWEB_REDFISH_ALLOW_DEPRECATED_INDICATORLED)
     {
-        setIndicatorLedState(asyncResp, *indicatorLed);
-        asyncResp->res.addHeader(boost::beast::http::field::warning,
-                                 "299 - \"IndicatorLED is deprecated. Use "
-                                 "LocationIndicatorActive instead.\"");
+        if (indicatorLed)
+        {
+            setIndicatorLedState(asyncResp, *indicatorLed);
+            asyncResp->res.addHeader(boost::beast::http::field::warning,
+                                     "299 - \"IndicatorLED is deprecated. Use "
+                                     "LocationIndicatorActive instead.\"");
+        }
     }
 
     if (powerRestorePolicy)


### PR DESCRIPTION
Cherry-picked merged upstream commit: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/82434

With this commit the IndicatorLED property will no longer be part of the Redfish response.

The IndicatorLED property has been deprecated by Redfish since September
2020. The Redfish Service Validator reports a WARNING for this property:

```
WARNING - IndicatorLED: The given property is deprecated: This property has been deprecated in favor of the `LocationIndicatorActive` property.
```

The LocationIndicatorActive property is now implemented in bmcweb in all places where IndicatorLED was implemented. So a new meson option (redfish-allow-deprecated-indicatorled) is being added to control whether this property is part of get or patch requests. The option is disabled by default with plans to remove the option by March 2026.

Tested:
 - Built with option enabled and confirmed IndicatorLED still part of Redfish responses and can be patched.
 - Built with option disabled and confirmed Redfish Service Validator no longer reports the warning.
 - Built with option disabled and confirmed IndicatorLED no longer part of Redfish responses and patch fails appropriately.
```
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"IndicatorLED":"Blinking"}' https://${bmc}/redfish/v1/Systems/system
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property IndicatorLED is not in the list of valid properties for the resource.",
        "MessageArgs": [
          "IndicatorLED"
        ],
        "MessageId": "Base.1.19.PropertyUnknown",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.PropertyUnknown",
    "message": "The property IndicatorLED is not in the list of valid properties for the resource."
  }
}

curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" -X PATCH -d '{"IndicatorLED":"Off"}' https://${bmc}/redfish/v1/Chassis/chassis
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property IndicatorLED is not in the list of valid properties for the resource.",
        "MessageArgs": [
          "IndicatorLED"
        ],
        "MessageId": "Base.1.19.PropertyUnknown",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the unknown property from the request body and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.PropertyUnknown",
    "message": "The property IndicatorLED is not in the list of valid properties for the resource."
  }
}
```

Change-Id: I2c0d415a7a54aa3122b18d2a1aa69bd9259d567e