### PR TITLE
1060: Ignore all ChapData errors and Bypass ACFWindow and PanelFunc without Backend (#949)(#1059)

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2213,8 +2213,8 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
                     const dbus::utility::DBusPropertiesMap& propertiesList) {
         if (ec)
         {
-            BMCWEB_LOG_ERROR << "Get ChapData D-bus error: " << ec.value();
-            messages::internalError(asyncResp->res);
+            // ChapData isn't that important. Ignore all errors.
+            BMCWEB_LOG_DEBUG << "Get ChapData D-bus error: " << ec.value();
             return;
         }
 

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2040,21 +2040,16 @@ inline void getIdlePowerSaver(const std::shared_ptr<bmcweb::AsyncResp>& aResp)
  */
 inline void doGetEnabledPanelFunctions(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    std::function<void(const std::vector<uint8_t>&)>&& callback)
+    std::function<void(const boost::system::error_code& ec,
+                       const std::vector<uint8_t>&)>&& callback)
 {
     BMCWEB_LOG_DEBUG << "Get Enabled Panel functions";
 
     crow::connections::systemBus->async_method_call(
-        [asyncResp, callback](const boost::system::error_code& ec,
-                              const std::vector<uint8_t>& enabledFuncs) {
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "Get Enabled Panel Functions D-bus error: "
-                             << ec.value();
-            messages::internalError(asyncResp->res);
-            return;
-        }
-        callback(enabledFuncs);
+        [asyncResp, callback{std::move(callback)}](
+            const boost::system::error_code& ec,
+            const std::vector<uint8_t>& enabledFuncs) {
+        callback(ec, enabledFuncs);
     },
         "com.ibm.PanelApp", "/com/ibm/panel_app", "com.ibm.panel",
         "getEnabledFunctions");
@@ -2067,7 +2062,19 @@ inline void getEnabledPanelFunctions(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
     doGetEnabledPanelFunctions(
-        asyncResp, [asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        asyncResp, [asyncResp](const boost::system::error_code& ec,
+                               const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            if (ec.value() != EBADR &&
+                ec.value() != boost::asio::error::host_unreachable)
+            {
+                BMCWEB_LOG_ERROR << "Get Enabled Panel Functions D-bus error: "
+                                 << ec.value();
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        }
         nlohmann::json& oem = asyncResp->res.jsonValue["Oem"];
         oem["IBM"]["@odata.type"] = "#OemComputerSystem.v1_0_0.IBM";
         oem["IBM"]["EnabledPanelFunctions"] = enabledFuncs;
@@ -2157,7 +2164,15 @@ inline void handleSystemActionsOemExecutePanelFunctionPost(
 
     doGetEnabledPanelFunctions(
         asyncResp,
-        [funcNo, asyncResp](const std::vector<uint8_t>& enabledFuncs) {
+        [funcNo, asyncResp](const boost::system::error_code& ec,
+                            const std::vector<uint8_t>& enabledFuncs) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "Get Enabled Panel Functions D-bus error: "
+                             << ec.value();
+            messages::internalError(asyncResp->res);
+            return;
+        }
         auto it = std::find(enabledFuncs.begin(), enabledFuncs.end(), funcNo);
         if (it == enabledFuncs.end())
         {


### PR DESCRIPTION
This retrofits 1110 commits to allow the situation without backend.

1 Bypass ACFWindow and PanelFunc without Backend (#946)

If Panel backend daemon is not running, redfish API may fail

```
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR systems.hpp:2710] Get Enabled Panel Functions D-bus error: 113
Apr 25 20:57:35 p10bmc bmcweb[727]: [CRITICAL error_messages.cpp:286] Internal Error \
           /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/systems.hpp(2711:40) \
          `redfish::getEnabledPanelFunctions(....)
Apr 25 20:57:35 p10bmc bmcweb[727]: [ERROR http_connection.hpp:514] 0x17bc500 Error while reading: stream truncated
```

Tested:
- Stop panel daemon
- redfsih GET passes
```
curl -k -X GET https://${bmc}:18080/redfish/v1/Systems/system
```

2. Ignore all ChapData errors (#1059)

Have seen pldm send back errors in cases like it is powering off. Just
ignore all ChapData errors. The HMC doesn't use ChapData. We will still
return a 500 here in 1050/1060 but for 1110, let's just ignore all
errors.
