### PR TITLE
1060: Fix obmc console handling issue

### DIFF
--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -288,9 +288,13 @@ class ConnectionImpl : public Connection
                                     size_t bytesRead) {
             if (ec)
             {
-                if (ec != boost::beast::websocket::error::closed &&
-                    ec != boost::asio::error::eof &&
-                    ec != boost::asio::ssl::error::stream_truncated)
+                if (ec == boost::beast::error::timeout)
+                {
+                    BMCWEB_LOG_WARNING << "doRead timeout: " << ec;
+                }
+                else if (ec != boost::beast::websocket::error::closed &&
+                         ec != boost::asio::error::eof &&
+                         ec != boost::asio::ssl::error::stream_truncated)
                 {
                     BMCWEB_LOG_ERROR << "doRead error " << ec;
                 }

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -3,6 +3,7 @@
 
 #include <async_resp.hpp>
 #include <boost/asio/buffer.hpp>
+#include <boost/asio/ssl/error.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
 #include <boost/beast/websocket.hpp>
 
@@ -287,7 +288,9 @@ class ConnectionImpl : public Connection
                                     size_t bytesRead) {
             if (ec)
             {
-                if (ec != boost::beast::websocket::error::closed)
+                if (ec != boost::beast::websocket::error::closed &&
+                    ec != boost::asio::error::eof &&
+                    ec != boost::asio::ssl::error::stream_truncated)
                 {
                     BMCWEB_LOG_ERROR << "doRead error " << ec;
                 }

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -1,13 +1,19 @@
 #pragma once
+#include "app.hpp"
+#include "async_resp.hpp"
+#include "privileges.hpp"
+#include "websocket.hpp"
+
 #include <sys/socket.h>
 
-#include <app.hpp>
-#include <async_resp.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/container/flat_map.hpp>
-#include <dbus_utility.hpp>
-#include <privileges.hpp>
-#include <websocket.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <array>
+#include <memory>
+#include <string>
+#include <string_view>
 
 namespace crow
 {

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -75,13 +75,21 @@ class ConsoleHandler : public std::enable_shared_from_this<ConsoleHandler>
         });
     }
 
+    static void afterSendEx(const std::weak_ptr<ConsoleHandler>& weak)
+    {
+        std::shared_ptr<ConsoleHandler> self = weak.lock();
+        if (self == nullptr)
+        {
+            return;
+        }
+        self->doRead();
+    }
+
     void doRead()
     {
-        std::size_t bytes = outputBuffer.capacity() - outputBuffer.size();
-
         BMCWEB_LOG_DEBUG << "Reading from socket";
         hostSocket.async_read_some(
-            outputBuffer.prepare(bytes),
+            boost::asio::buffer(outputBuffer),
             [this, weakSelf(weak_from_this())](
                 const boost::system::error_code& ec, std::size_t bytesRead) {
             BMCWEB_LOG_DEBUG << "read done.  Read " << bytesRead << " bytes";
@@ -97,13 +105,9 @@ class ConsoleHandler : public std::enable_shared_from_this<ConsoleHandler>
                 conn.close("Error connecting to host port");
                 return;
             }
-            outputBuffer.commit(bytesRead);
-            std::string_view payload(
-                static_cast<const char*>(outputBuffer.data().data()),
-                bytesRead);
-            conn.sendBinary(payload);
-            outputBuffer.consume(bytesRead);
-            doRead();
+            std::string_view payload(outputBuffer.data(), bytesRead);
+            self->conn.sendEx(crow::websocket::MessageType::Binary, payload,
+                              std::bind_front(afterSendEx, weak_from_this()));
         });
     }
 
@@ -135,7 +139,7 @@ class ConsoleHandler : public std::enable_shared_from_this<ConsoleHandler>
 
     boost::asio::local::stream_protocol::socket hostSocket;
 
-    boost::beast::flat_static_buffer<4096> outputBuffer;
+    std::array<char, 4096> outputBuffer{};
 
     std::string inputBuffer;
     bool doingWrite = false;

--- a/include/obmc_console.hpp
+++ b/include/obmc_console.hpp
@@ -4,7 +4,7 @@
 #include <app.hpp>
 #include <async_resp.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
-#include <boost/container/flat_set.hpp>
+#include <boost/container/flat_map.hpp>
 #include <dbus_utility.hpp>
 #include <privileges.hpp>
 #include <websocket.hpp>
@@ -14,104 +14,255 @@ namespace crow
 namespace obmc_console
 {
 
-static std::unique_ptr<boost::asio::local::stream_protocol::socket> hostSocket;
+// Update this value each time we add new console route.
+static constexpr const uint maxSessions = 32;
 
-static std::array<char, 4096> outputBuffer;
-static std::string inputBuffer;
-
-static boost::container::flat_set<crow::websocket::Connection*> sessions;
-
-static bool doingWrite = false;
-
-inline void doWrite()
+class ConsoleHandler : public std::enable_shared_from_this<ConsoleHandler>
 {
-    if (doingWrite)
+  public:
+    ConsoleHandler(boost::asio::io_context& ioc,
+                   crow::websocket::Connection& connIn) :
+        hostSocket(ioc),
+        conn(connIn)
+    {}
+
+    ~ConsoleHandler() = default;
+
+    ConsoleHandler(const ConsoleHandler&) = delete;
+    ConsoleHandler(ConsoleHandler&&) = delete;
+    ConsoleHandler& operator=(const ConsoleHandler&) = delete;
+    ConsoleHandler& operator=(ConsoleHandler&&) = delete;
+
+    void doWrite()
     {
-        BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
-        return;
-    }
-
-    if (inputBuffer.empty())
-    {
-        BMCWEB_LOG_DEBUG << "Outbuffer empty.  Bailing out";
-        return;
-    }
-
-    if (!hostSocket)
-    {
-        BMCWEB_LOG_ERROR << "doWrite(): Socket closed.";
-        return;
-    }
-
-    doingWrite = true;
-    hostSocket->async_write_some(
-        boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
-        [](boost::beast::error_code ec, std::size_t bytesWritten) {
-        doingWrite = false;
-        inputBuffer.erase(0, bytesWritten);
-
-        if (ec == boost::asio::error::eof)
+        if (doingWrite)
         {
-            for (crow::websocket::Connection* session : sessions)
+            BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
+            return;
+        }
+
+        if (inputBuffer.empty())
+        {
+            BMCWEB_LOG_DEBUG << "Outbuffer empty.  Bailing out";
+            return;
+        }
+
+        doingWrite = true;
+        hostSocket.async_write_some(
+            boost::asio::buffer(inputBuffer.data(), inputBuffer.size()),
+            [weak(weak_from_this())](const boost::beast::error_code& ec,
+                                     std::size_t bytesWritten) {
+            std::shared_ptr<ConsoleHandler> self = weak.lock();
+            if (self == nullptr)
             {
-                session->close("Error in reading to host port");
+                return;
             }
-            return;
-        }
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "Error in host serial write " << ec;
-            return;
-        }
-        doWrite();
-    });
+
+            self->doingWrite = false;
+            self->inputBuffer.erase(0, bytesWritten);
+
+            if (ec == boost::asio::error::eof)
+            {
+                self->conn.close("Error in reading to host port");
+                return;
+            }
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Error in host serial write " << ec;
+                return;
+            }
+            self->doWrite();
+        });
+    }
+
+    void doRead()
+    {
+        std::size_t bytes = outputBuffer.capacity() - outputBuffer.size();
+
+        BMCWEB_LOG_DEBUG << "Reading from socket";
+        hostSocket.async_read_some(
+            outputBuffer.prepare(bytes),
+            [this, weakSelf(weak_from_this())](
+                const boost::system::error_code& ec, std::size_t bytesRead) {
+            BMCWEB_LOG_DEBUG << "read done.  Read " << bytesRead << " bytes";
+            std::shared_ptr<ConsoleHandler> self = weakSelf.lock();
+            if (self == nullptr)
+            {
+                return;
+            }
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Couldn't read from host serial port: "
+                                 << ec.message();
+                conn.close("Error connecting to host port");
+                return;
+            }
+            outputBuffer.commit(bytesRead);
+            std::string_view payload(
+                static_cast<const char*>(outputBuffer.data().data()),
+                bytesRead);
+            conn.sendBinary(payload);
+            outputBuffer.consume(bytesRead);
+            doRead();
+        });
+    }
+
+    void connect()
+    {
+        const std::string consoleName("\0obmc-console", 13);
+        boost::asio::local::stream_protocol::endpoint ep(consoleName);
+
+        hostSocket.async_connect(ep, [this, weakSelf(weak_from_this())](
+                                         const boost::system::error_code& ec) {
+            std::shared_ptr<ConsoleHandler> self = weakSelf.lock();
+            if (self == nullptr)
+            {
+                return;
+            }
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "Failed to call console Connect() method"
+                                 << " DBUS error: " << ec.message();
+
+                conn.close("Internal Error");
+                return;
+            }
+
+            doWrite();
+            doRead();
+        });
+    }
+
+    boost::asio::local::stream_protocol::socket hostSocket;
+
+    boost::beast::flat_static_buffer<4096> outputBuffer;
+
+    std::string inputBuffer;
+    bool doingWrite = false;
+    crow::websocket::Connection& conn;
+};
+
+using ObmcConsoleMap = boost::container::flat_map<
+    crow::websocket::Connection*, std::shared_ptr<ConsoleHandler>, std::less<>,
+    std::vector<std::pair<crow::websocket::Connection*,
+                          std::shared_ptr<ConsoleHandler>>>>;
+
+inline ObmcConsoleMap& getConsoleHandlerMap()
+{
+    static ObmcConsoleMap map;
+    return map;
 }
 
-inline void doRead()
+// Remove connection from the connection map and if connection map is empty
+// then remove the handler from handlers map.
+inline void onClose(crow::websocket::Connection& conn, const std::string& err)
 {
-    if (!hostSocket)
+    BMCWEB_LOG_INFO << "Closing websocket. Reason: " << err;
+
+    auto iter = getConsoleHandlerMap().find(&conn);
+    if (iter == getConsoleHandlerMap().end())
     {
-        BMCWEB_LOG_ERROR << "doRead(): Socket closed.";
+        BMCWEB_LOG_CRITICAL << "Unable to find connection " << &conn;
         return;
     }
+    BMCWEB_LOG_DEBUG << "Remove connection " << &conn << " from obmc console";
 
-    BMCWEB_LOG_DEBUG << "Reading from socket";
-    hostSocket->async_read_some(
-        boost::asio::buffer(outputBuffer.data(), outputBuffer.size()),
-        [](const boost::system::error_code& ec, std::size_t bytesRead) {
-        BMCWEB_LOG_DEBUG << "read done.  Read " << bytesRead << " bytes";
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR << "Couldn't read from host serial port: " << ec;
-            for (crow::websocket::Connection* session : sessions)
-            {
-                session->close("Error in connecting to host port");
-            }
-            return;
-        }
-        std::string_view payload(outputBuffer.data(), bytesRead);
-        for (crow::websocket::Connection* session : sessions)
-        {
-            session->sendBinary(payload);
-        }
-        doRead();
-    });
+    // Removed last connection so remove the path
+    getConsoleHandlerMap().erase(iter);
 }
 
-inline void connectHandler(const boost::system::error_code& ec)
+inline void connectConsoleSocket(crow::websocket::Connection& conn)
 {
-    if (ec)
+    // Look up the handler
+    auto iter = getConsoleHandlerMap().find(&conn);
+    if (iter == getConsoleHandlerMap().end())
     {
-        BMCWEB_LOG_ERROR << "Couldn't connect to host serial port: " << ec;
-        for (crow::websocket::Connection* session : sessions)
-        {
-            session->close("Error in connecting to host port");
-        }
+        BMCWEB_LOG_ERROR << "Failed to find the handler";
+        conn.close("Internal error");
         return;
     }
 
-    doWrite();
-    doRead();
+    iter->second->connect();
+}
+
+// Query consoles from DBUS and find the matching to the
+// rules string.
+inline void onOpen(crow::websocket::Connection& conn)
+{
+    BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+
+    if (getConsoleHandlerMap().size() >= maxSessions)
+    {
+        conn.close("Max sessions are already connected");
+        return;
+    }
+
+    // Ensure user has ConfigureManager, setting above does nothing
+    auto getUserInfo =
+        [&conn](const boost::system::error_code& ec,
+                const dbus::utility::DBusPropertiesMap& userInfo) {
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR << "GetUserInfo failed...";
+            conn.close("Failed to get user information");
+            return;
+        }
+
+        const std::string* userRolePtr = nullptr;
+        auto userInfoIter = std::find_if(
+            userInfo.begin(), userInfo.end(),
+            [](const auto& p) { return p.first == "UserPrivilege"; });
+        if (userInfoIter != userInfo.end())
+        {
+            userRolePtr = std::get_if<std::string>(&userInfoIter->second);
+        }
+
+        std::string userRole{};
+        if (userRolePtr != nullptr)
+        {
+            userRole = *userRolePtr;
+            BMCWEB_LOG_DEBUG << "userName = " << conn.getUserName()
+                             << " userRole = " << *userRolePtr;
+        }
+
+        // Get the user privileges from the role
+        ::redfish::Privileges userPrivileges =
+            ::redfish::getUserPrivileges(userRole);
+
+        const ::redfish::Privileges requiredPrivileges{"ConfigureManager"};
+
+        if (!userPrivileges.isSupersetOf(requiredPrivileges))
+        {
+            BMCWEB_LOG_DEBUG << "User " << conn.getUserName()
+                             << " not authorized for host console connection";
+            conn.close("Unauthorized access");
+            return;
+        }
+
+        std::shared_ptr<ConsoleHandler> handler =
+            std::make_shared<ConsoleHandler>(conn.getIoContext(), conn);
+        getConsoleHandlerMap().emplace(&conn, handler);
+
+        connectConsoleSocket(conn);
+    };
+
+    crow::connections::systemBus->async_method_call(
+        std::move(getUserInfo), "xyz.openbmc_project.User.Manager",
+        "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
+        "GetUserInfo", conn.getUserName());
+}
+
+inline void onMessage(crow::websocket::Connection& conn,
+                      const std::string& data, bool /*isBinary*/)
+{
+    auto handler = getConsoleHandlerMap().find(&conn);
+    if (handler == getConsoleHandlerMap().end())
+    {
+        BMCWEB_LOG_CRITICAL << "Unable to find connection " << &conn;
+        return;
+    }
+    handler->second->inputBuffer += data;
+    handler->second->doWrite();
 }
 
 inline void requestRoutes(App& app)
@@ -119,85 +270,9 @@ inline void requestRoutes(App& app)
     BMCWEB_ROUTE(app, "/console0")
         .privileges({{"ConfigureManager"}})
         .websocket()
-        .onopen([](crow::websocket::Connection& conn) {
-        BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
-        // Ensure user has ConfigureManager, setting above does nothing
-        auto getUserInfo =
-            [&conn](const boost::system::error_code& ec,
-                    const dbus::utility::DBusPropertiesMap& userInfo) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR << "GetUserInfo failed...";
-                conn.close("Failed to get user information");
-                return;
-            }
-
-            const std::string* userRolePtr = nullptr;
-            auto userInfoIter = std::find_if(
-                userInfo.begin(), userInfo.end(),
-                [](const auto& p) { return p.first == "UserPrivilege"; });
-            if (userInfoIter != userInfo.end())
-            {
-                userRolePtr = std::get_if<std::string>(&userInfoIter->second);
-            }
-
-            std::string userRole{};
-            if (userRolePtr != nullptr)
-            {
-                userRole = *userRolePtr;
-                BMCWEB_LOG_DEBUG << "userName = " << conn.getUserName()
-                                 << " userRole = " << *userRolePtr;
-            }
-
-            // Get the user privileges from the role
-            ::redfish::Privileges userPrivileges =
-                ::redfish::getUserPrivileges(userRole);
-
-            const ::redfish::Privileges requiredPrivileges{"ConfigureManager"};
-
-            if (!userPrivileges.isSupersetOf(requiredPrivileges))
-            {
-                BMCWEB_LOG_DEBUG
-                    << "User " << conn.getUserName()
-                    << " not authorized for host console connection";
-                conn.close("Unathourized access");
-                return;
-            }
-
-            sessions.insert(&conn);
-            if (hostSocket == nullptr)
-            {
-                const std::string consoleName("\0obmc-console", 13);
-                boost::asio::local::stream_protocol::endpoint ep(consoleName);
-
-                hostSocket = std::make_unique<
-                    boost::asio::local::stream_protocol::socket>(
-                    conn.getIoContext());
-                hostSocket->async_connect(ep, connectHandler);
-            }
-        };
-        crow::connections::systemBus->async_method_call(
-            std::move(getUserInfo), "xyz.openbmc_project.User.Manager",
-            "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager",
-            "GetUserInfo", conn.getUserName());
-    })
-        .onclose([](crow::websocket::Connection& conn,
-                    [[maybe_unused]] const std::string& reason) {
-        BMCWEB_LOG_INFO << "Closing websocket. Reason: " << reason;
-
-        sessions.erase(&conn);
-        if (sessions.empty())
-        {
-            hostSocket = nullptr;
-            inputBuffer.clear();
-            inputBuffer.shrink_to_fit();
-        }
-    })
-        .onmessage([]([[maybe_unused]] crow::websocket::Connection& conn,
-                      const std::string& data, [[maybe_unused]] bool isBinary) {
-        inputBuffer += data;
-        doWrite();
-    });
+        .onopen(onOpen)
+        .onclose(onClose)
+        .onmessage(onMessage);
 }
 } // namespace obmc_console
 } // namespace crow


### PR DESCRIPTION
The coredump had happened on session management on obmc_console/websocket because a session object (in an array of sessions) may already become invalid during doRead.
This  can be avoided by moving the sessions into a map of connection and its console socket object is deleted as a part of connection handler object.

The key commit that cherry-picked is:

- Introduce ConsoleHandler class under obmc_console (https://github.com/ibm-openbmc/bmcweb/commit/f948d810b7c8dad91203f050923db51a16cdacc1)

Added new ConsoleHandler class to prepare for the multiple consoles
support. All global fields are moved to the ConsoleHandler class and a
new global map added to remember the ConsoleHandler for each console
path. There is single ConsoleHandler per connection so we don't need
session map per route. There is a limit added for max number of
connection allowed to avoid any service attacks.

Testing:
    - Make sure that single console works fine and data is seen on the
      console.
    - Make sure that multiple consoles of type host console are created
      and data is seen on all consoles. Also using traces made sure
      that new handlers are destroyed.

Change-Id: I77a58a3a186e87611219aed90b221f9b8be7fa2f
