### PR TITLE
1110: Fix 204/304 incorrectly tracing CRITICAL message

### DIFF
--- a/http/http2_connection.hpp
+++ b/http/http2_connection.hpp
@@ -24,6 +24,7 @@
 #include <boost/beast/http/write.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/system/error_code.hpp>
+#include <boost/url/url_view.hpp>
 
 #include <array>
 #include <atomic>
@@ -170,7 +171,12 @@ class HTTP2Connection :
 
         completeResponseFields(stream.accept, res);
         res.addHeader(boost::beast::http::field::date, getCachedDateStr());
-        res.preparePayload();
+        boost::urls::url_view urlView;
+        if (stream.req != nullptr)
+        {
+            urlView = stream.req->url();
+        }
+        res.preparePayload(urlView);
 
         boost::beast::http::fields& fields = res.fields();
         std::string code = std::to_string(res.resultInt());

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -31,6 +31,7 @@
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
 #include <boost/beast/websocket.hpp>
+#include <boost/url/url_view.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -736,7 +737,13 @@ class Connection :
     void doWrite()
     {
         BMCWEB_LOG_DEBUG("{} doWrite", logPtr(this));
-        res.preparePayload();
+
+        boost::urls::url_view urlView;
+        if (req != nullptr)
+        {
+            urlView = req->url();
+        }
+        res.preparePayload(urlView);
 
         startDeadline();
         boost::beast::async_write(

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -9,6 +9,7 @@
 #include <boost/beast/core/flat_static_buffer.hpp>
 #include <boost/beast/http/basic_dynamic_body.hpp>
 #include <boost/beast/http/message.hpp>
+#include <boost/url/url_view.hpp>
 #include <nlohmann/json.hpp>
 
 #include <optional>
@@ -178,10 +179,8 @@ struct Response
         return response.body().payloadSize();
     }
 
-    void preparePayload()
+    void preparePayload(const boost::urls::url_view& urlView)
     {
-        // This code is a throw-free equivalent to
-        // beast::http::message::prepare_payload
         std::optional<uint64_t> pSize = response.body().payloadSize();
 
         using http::status;
@@ -201,8 +200,8 @@ struct Response
         {
             BMCWEB_LOG_CRITICAL("{} Response content provided but code was "
                                 "no-content or not_modified, which aren't "
-                                "allowed to have a body",
-                                logPtr(this));
+                                "allowed to have a body for url : \"{}\"",
+                                logPtr(this), urlView.path());
             response.content_length(0);
             return;
         }

--- a/http/http_response.hpp
+++ b/http/http_response.hpp
@@ -195,8 +195,8 @@ struct Response
         }
         response.content_length(*pSize);
 
-        if (is1XXReturn || result() == status::no_content ||
-            result() == status::not_modified)
+        if ((*pSize > 0) && (is1XXReturn || result() == status::no_content ||
+                             result() == status::not_modified))
         {
             BMCWEB_LOG_CRITICAL("{} Response content provided but code was "
                                 "no-content or not_modified, which aren't "

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2971,8 +2971,6 @@ inline void handleComputerSystemPatch(
                 }
     // clang-format on
 
-    asyncResp->res.result(boost::beast::http::status::no_content);
-
     if (assetTag)
     {
         setAssetTag(asyncResp, *assetTag);


### PR DESCRIPTION
Trace URI on the existing CRITICAL message when a body exists but HTTP return code was Informational responses (100 – 199), no-content (204), or not_modified (304).

Tested: With these changes, the URI is traced on the CRITICAL message:

```
 curl --http2 -k -H "Content-Type: application/json" \
 -d '{"PowerRestorePolicy":"LastState"}' \
 -X PATCH https://${bmc}/redfish/v1/Systems/system

root@p10bmc:~# journalctl | grep Response
Jun 20 15:30:46 p10bmc bmcwebd[296]: [http_response.hpp:213]
 0x1353670 Response content provided but code was no-content
 or not_modified, which aren't allowed to
 have a body for url : "/redfish/v1/Systems/system"
```

Change-Id: I1ef618600642d355fc9f935d055b011e044caf5c