### PR TITLE
Audit Log: Expect USER_LOGIN audit entries

### DIFF
--- a/redfish-core/lib/systems_logservices_audit.hpp
+++ b/redfish-core/lib/systems_logservices_audit.hpp
@@ -188,7 +188,8 @@ static AuditLogParseError fillAuditLogEntryJson(
     // Fill the MessageArgs into the Message
     if (!messageArgs.empty())
     {
-        if (messageArgs[0] != "USYS_CONFIG")
+        if ((messageArgs[0] != "USYS_CONFIG") &&
+            (messageArgs[0] != "USER_LOGIN"))
         {
             BMCWEB_LOG_WARNING("Unexpected audit log entry type: {}",
                                messageArgs[0]);


### PR DESCRIPTION
The phosphor-auditlog backend is parsing USER_LOGIN entries into the same format as USYS_CONFIG entries. [1] Don't warn under DEBUG when these entries are seen.

Tested: Confirmed warning no longer displayed when these entries are included in the GetLatestEntries response.

[1] https://github.com/ibm-openbmc/phosphor-logging/pull/130