### PR TITLE
Fix Privileges warnings (#1147)

### DIFF
--- a/redfish-core/include/privileges.hpp
+++ b/redfish-core/include/privileges.hpp
@@ -44,7 +44,7 @@ constexpr const size_t maxPrivilegeCount = 32;
  * "hostconsole" user group. This privilege is required to access the host
  * console.
  */
-static const std::array<std::string, maxPrivilegeCount> privilegeNames{
+constexpr std::array<std::string_view, maxPrivilegeCount> privilegeNames{
     "Login",
     "ConfigureManager",
     "ConfigureComponents",


### PR DESCRIPTION
Commit 9db1ebf [1]  mistakenly negate the upstream change [2][3]. This fixes the mistake to align with the upstream in handling privileges.

---

After splitting up the compile units, warnings start showing up on the console about privileges.  This is due to them being a static global, and not shared between the compile units.

Move the array to a constexpr structure so that all compile units see the same init.

[1] https://github.com/ibm-openbmc/bmcweb/commit/9db1ebf8440299fdc37b2919e0aac79193a64814
[2] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/70809
[3] https://github.com/ibm-openbmc/bmcweb/commit/ac25adb8

Change-Id: I6e035342a5b229a0601c02092ca3ce665b14bbdb