### PR TITLE
1120: Redo Assembly using upstream

### DIFF
--- a/docs/Redfish.md
+++ b/docs/Redfish.md
@@ -483,6 +483,20 @@ Fields common to all schemas
 - SparePartNumber
 - Status
 
+#### /redfish/v1/Chassis/{ChassisId}/Assembly
+
+##### Assemblies
+
+- Assemblies
+- `Assemblies@odata.count`
+
+###### Assembly
+
+- Model
+- PartNumber
+- SerialNumber
+- SparePartNumber
+
 ### /redfish/v1/EventService/
 
 #### EventService

--- a/docs/Redfish.md
+++ b/docs/Redfish.md
@@ -492,6 +492,7 @@ Fields common to all schemas
 
 ###### Assembly
 
+- LocationIndicatorActive
 - Model
 - PartNumber
 - SerialNumber

--- a/redfish-core/include/utils/assembly_utils.hpp
+++ b/redfish-core/include/utils/assembly_utils.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "boost_formatters.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "human_sort.hpp"
+#include "logging.hpp"
+#include "utils/chassis_utils.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/message/native_types.hpp>
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace redfish
+{
+
+static constexpr std::array<std::string_view, 1> assemblyInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Panel"};
+
+namespace assembly_utils
+{
+
+inline void afterGetChassisAssembly(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::function<void(const boost::system::error_code&,
+                       const std::vector<std::string>& sortedAssemblyList)>&
+        callback,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths)
+{
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::io_error || ec.value() == EBADR)
+        {
+            // Not found
+            callback(ec, std::vector<std::string>());
+            return;
+        }
+
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    std::vector<std::string> sortedAssemblyList = subtreePaths;
+    std::ranges::sort(sortedAssemblyList, AlphanumLess<std::string>());
+
+    callback(ec, sortedAssemblyList);
+}
+
+/**
+ * @brief Get chassis path with given chassis ID
+ * @param[in] asyncResp - Shared pointer for asynchronous calls.
+ * @param[in] chassisId - Chassis to which the assemblies are
+ * associated.
+ * @param[in] callback
+ *
+ * @return None.
+ */
+inline void getChassisAssembly(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisId,
+    std::function<void(const boost::system::error_code& ec,
+                       const std::vector<std::string>& sortedAssemblyList)>&&
+        callback)
+{
+    BMCWEB_LOG_DEBUG("Get ChassisAssembly");
+
+    dbus::utility::getAssociatedSubTreePathsById(
+        chassisId, "/xyz/openbmc_project/inventory", chassisInterfaces,
+        "containing", assemblyInterfaces,
+        std::bind_front(afterGetChassisAssembly, asyncResp,
+                        std::move(callback)));
+}
+
+} // namespace assembly_utils
+} // namespace redfish

--- a/redfish-core/include/utils/assembly_utils.hpp
+++ b/redfish-core/include/utils/assembly_utils.hpp
@@ -4,6 +4,7 @@
 
 #include "async_resp.hpp"
 #include "boost_formatters.hpp"
+#include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
 #include "error_messages.hpp"
 #include "human_sort.hpp"
@@ -13,24 +14,34 @@
 #include <asm-generic/errno.h>
 
 #include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <iterator>
 #include <memory>
-#include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
 namespace redfish
 {
 
-static constexpr std::array<std::string_view, 1> assemblyInterfaces = {
-    "xyz.openbmc_project.Inventory.Item.Panel"};
+static constexpr std::array<std::string_view, 9> assemblyInterfaces = {
+    "xyz.openbmc_project.Inventory.Item.Battery",
+    "xyz.openbmc_project.Inventory.Item.Board",
+    "xyz.openbmc_project.Inventory.Item.Board.Motherboard",
+    "xyz.openbmc_project.Inventory.Item.Connector",
+    "xyz.openbmc_project.Inventory.Item.DiskBackplane",
+    "xyz.openbmc_project.Inventory.Item.Drive",
+    "xyz.openbmc_project.Inventory.Item.Panel",
+    "xyz.openbmc_project.Inventory.Item.Tpm",
+    "xyz.openbmc_project.Inventory.Item.Vrm"};
 
 namespace assembly_utils
 {
@@ -83,9 +94,182 @@ inline void getChassisAssembly(
 
     dbus::utility::getAssociatedSubTreePathsById(
         chassisId, "/xyz/openbmc_project/inventory", chassisInterfaces,
-        "containing", assemblyInterfaces,
+        "assembly", assemblyInterfaces,
         std::bind_front(afterGetChassisAssembly, asyncResp,
                         std::move(callback)));
+}
+
+/**
+ * @brief API used to fill the Assembly id of the assembled object that
+ *        assembled in the given assembly parent object path.
+ *
+ *        bmcweb using the sequential numeric value by sorting the
+ *        assembled objects instead of the assembled object dbus id
+ *        for the Redfish Assembly implementation.
+ *
+ * @param[in] asyncResp - The redfish response to return.
+ * @param[in] assemblyParentServ - The assembly parent dbus service name.
+ * @param[in] assemblyParentObjPath - The assembly parent dbus object path.
+ * @param[in] assemblyParentIface - The assembly parent dbus interface name
+ *                                  to valid the supports in the bmcweb.
+ * @param[in] assemblyUriPropPath - The redfish property path to fill with id.
+ * @param[in] assembledObjPath - The assembled object that need to fill with
+ *                               its id. Used to check in the parent assembly
+ *                               associations.
+ * @param[in] assembledUriVal - The assembled object redfish uri value that
+ *                              need to replace with its id.
+ *
+ * @return The redfish response with assembled object id in the given
+ *         redfish property path if success else returns the error.
+ */
+inline void fillWithAssemblyId(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& assemblyParentServ,
+    const sdbusplus::message::object_path& assemblyParentObjPath,
+    const std::string& assemblyParentIface,
+    const nlohmann::json::json_pointer& assemblyUriPropPath,
+    const sdbusplus::message::object_path& assembledObjPath,
+    const std::string& assembledUriVal)
+{
+    if (assemblyParentIface != "xyz.openbmc_project.Inventory.Item.Chassis")
+    {
+        // Currently, bmcweb supporting only chassis assembly uri so return
+        // error if unsupported assembly uri interface was given
+        BMCWEB_LOG_ERROR(
+            "Unsupported interface [{}] was given to fill assembly id. Please add support in the bmcweb",
+            assemblyParentIface);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    using associationList =
+        std::vector<std::tuple<std::string, std::string, std::string>>;
+
+    sdbusplus::asio::getProperty<associationList>( //
+        *crow::connections::systemBus, assemblyParentServ,
+        assemblyParentObjPath.str,
+        "xyz.openbmc_project.Association.Definitions", "Associations",
+        [asyncResp, assemblyUriPropPath, assemblyParentObjPath,
+         assembledObjPath,
+         assembledUriVal](const boost::system::error_code& ec,
+                          const associationList& associations) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error [{}  : {}] when tried to get the Associations from [{}] to fill Assembly id of the assembled object [{}]",
+                    ec.value(), ec.message(), assemblyParentObjPath.str,
+                    assembledObjPath.str);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            std::vector<std::string> assemblyAssoc;
+            for (const auto& association : associations)
+            {
+                if (std::get<0>(association) != "assembly")
+                {
+                    continue;
+                }
+                assemblyAssoc.emplace_back(std::get<2>(association));
+            }
+
+            if (assemblyAssoc.empty())
+            {
+                BMCWEB_LOG_ERROR(
+                    "No assembly associations in the [{}] to fill Assembly id of the assembled object [{}]",
+                    assemblyParentObjPath.str, assembledObjPath.str);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Mak sure whether the retrieved assembly associations are
+            // implemented before finding the assembly id as per bmcweb Assembly
+            // design.
+            dbus::utility::getSubTree(
+                "/xyz/openbmc_project/inventory", 0, chassisAssemblyInterfaces,
+                [asyncResp, assemblyUriPropPath, assemblyParentObjPath,
+                 assembledObjPath, assemblyAssoc, assembledUriVal](
+                    const boost::system::error_code& ec1,
+                    const dbus::utility::MapperGetSubTreeResponse& objects) {
+                    if (ec1)
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "DBUS response error [{} : {}] when tried to get the subtree to check assembled objects implementation of the [{}] to find assembled object id of the [{}] to fill in the URI property",
+                            ec1.value(), ec1.message(),
+                            assemblyParentObjPath.str, assembledObjPath.str);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    if (objects.empty())
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "No objects in the [{}] to check assembled objects implementation to fill the assembled object [{}] id in the URI property",
+                            assemblyParentObjPath.str, assembledObjPath.str);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    std::vector<std::string> implAssemblyAssocs;
+                    for (const auto& object : objects)
+                    {
+                        auto it =
+                            std::ranges::find(assemblyAssoc, object.first);
+                        if (it != assemblyAssoc.end())
+                        {
+                            implAssemblyAssocs.emplace_back(*it);
+                        }
+                    }
+
+                    if (implAssemblyAssocs.empty())
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "The assembled objects of the [{}] are not implemented so unable to fill the assembled object [{}] id in the URI property",
+                            assemblyParentObjPath.str, assembledObjPath.str);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    // sort  the implemented assemply object as per bmcweb
+                    // design to match with Assembly GET and PATCH handler.
+                    std::ranges::sort(implAssemblyAssocs);
+
+                    auto assembledObjectIt = std::ranges::find(
+                        implAssemblyAssocs, assembledObjPath.str);
+
+                    if (assembledObjectIt == implAssemblyAssocs.end())
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "The assembled object [{}] in the object [{}] is not implemented so unable to fill assembled object id in the URI property",
+                            assembledObjPath.str, assemblyParentObjPath.str);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+
+                    auto assembledObjectId = std::distance(
+                        implAssemblyAssocs.begin(), assembledObjectIt);
+
+                    std::string::size_type assembledObjectNamePos =
+                        assembledUriVal.rfind(assembledObjPath.filename());
+
+                    if (assembledObjectNamePos == std::string::npos)
+                    {
+                        BMCWEB_LOG_ERROR(
+                            "The assembled object name [{}] is not found in the redfish property value [{}] to replace with assembled object id [{}]",
+                            assembledObjPath.filename(), assembledUriVal,
+                            assembledObjectId);
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    std::string uriValwithId(assembledUriVal);
+                    uriValwithId.replace(assembledObjectNamePos,
+                                         assembledObjPath.filename().length(),
+                                         std::to_string(assembledObjectId));
+
+                    asyncResp->res.jsonValue[assemblyUriPropPath] =
+                        uriValwithId;
+                });
+        });
 }
 
 } // namespace assembly_utils

--- a/redfish-core/include/utils/asset_utils.hpp
+++ b/redfish-core/include/utils/asset_utils.hpp
@@ -28,7 +28,7 @@ inline void extractAssetInfo(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const nlohmann::json::json_pointer& jsonKeyName,
     const dbus::utility::DBusPropertiesMap& assetList,
-    bool includeSparePartNumber = false)
+    bool includeSparePartNumber = false, bool includeManufacturer = true)
 {
     const std::string* manufacturer = nullptr;
     const std::string* model = nullptr;
@@ -48,7 +48,7 @@ inline void extractAssetInfo(
 
     nlohmann::json& assetData = asyncResp->res.jsonValue[jsonKeyName];
 
-    if (manufacturer != nullptr)
+    if (includeManufacturer && manufacturer != nullptr)
     {
         assetData["Manufacturer"] = *manufacturer;
     }
@@ -72,15 +72,15 @@ inline void extractAssetInfo(
     }
 }
 
-inline void getAssetInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                         const std::string& serviceName,
-                         const std::string& dbusPath,
-                         const nlohmann::json::json_pointer& jsonKeyName,
-                         bool includeSparePartNumber = false)
+inline void getAssetInfo(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& serviceName, const std::string& dbusPath,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    bool includeSparePartNumber = false, bool includeManufacturer = true)
 {
     dbus::utility::getAllProperties(
         serviceName, dbusPath, "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [asyncResp, jsonKeyName, includeSparePartNumber](
+        [asyncResp, jsonKeyName, includeSparePartNumber, includeManufacturer](
             const boost::system::error_code& ec,
             const dbus::utility::DBusPropertiesMap& assetList) {
             if (ec)
@@ -94,7 +94,7 @@ inline void getAssetInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                 return;
             }
             extractAssetInfo(asyncResp, jsonKeyName, assetList,
-                             includeSparePartNumber);
+                             includeSparePartNumber, includeManufacturer);
         });
 }
 

--- a/redfish-core/include/utils/asset_utils.hpp
+++ b/redfish-core/include/utils/asset_utils.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+#include "utils/dbus_utils.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/unpack_properties.hpp>
+
+#include <functional>
+#include <memory>
+#include <ranges>
+#include <string>
+
+namespace redfish
+{
+namespace asset_utils
+{
+
+inline void extractAssetInfo(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonKeyName,
+    const dbus::utility::DBusPropertiesMap& assetList,
+    bool includeSparePartNumber = false)
+{
+    const std::string* manufacturer = nullptr;
+    const std::string* model = nullptr;
+    const std::string* partNumber = nullptr;
+    const std::string* serialNumber = nullptr;
+    const std::string* sparePartNumber = nullptr;
+
+    const bool success = sdbusplus::unpackPropertiesNoThrow(
+        dbus_utils::UnpackErrorPrinter(), assetList, "Manufacturer",
+        manufacturer, "Model", model, "PartNumber", partNumber, "SerialNumber",
+        serialNumber, "SparePartNumber", sparePartNumber);
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    nlohmann::json& assetData = asyncResp->res.jsonValue[jsonKeyName];
+
+    if (manufacturer != nullptr)
+    {
+        assetData["Manufacturer"] = *manufacturer;
+    }
+    if (model != nullptr)
+    {
+        assetData["Model"] = *model;
+    }
+    if (partNumber != nullptr)
+    {
+        assetData["PartNumber"] = *partNumber;
+    }
+    if (serialNumber != nullptr)
+    {
+        assetData["SerialNumber"] = *serialNumber;
+    }
+    // SparePartNumber is optional on D-Bus so skip if it is empty
+    if (includeSparePartNumber && sparePartNumber != nullptr &&
+        !sparePartNumber->empty())
+    {
+        assetData["SparePartNumber"] = *sparePartNumber;
+    }
+}
+
+inline void getAssetInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& serviceName,
+                         const std::string& dbusPath,
+                         const nlohmann::json::json_pointer& jsonKeyName,
+                         bool includeSparePartNumber = false)
+{
+    dbus::utility::getAllProperties(
+        serviceName, dbusPath, "xyz.openbmc_project.Inventory.Decorator.Asset",
+        [asyncResp, jsonKeyName, includeSparePartNumber](
+            const boost::system::error_code& ec,
+            const dbus::utility::DBusPropertiesMap& assetList) {
+            if (ec)
+            {
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error for Properties {}",
+                                     ec.value());
+                    messages::internalError(asyncResp->res);
+                }
+                return;
+            }
+            extractAssetInfo(asyncResp, jsonKeyName, assetList,
+                             includeSparePartNumber);
+        });
+}
+
+} // namespace asset_utils
+} // namespace redfish

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "app.hpp"
+#include "assembly_battery_cm.hpp"
 #include "async_resp.hpp"
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
@@ -24,19 +25,14 @@
 #include <sdbusplus/asio/property.hpp>
 #include <sdbusplus/unpack_properties.hpp>
 
-#include <algorithm>
-#include <array>
 #include <cstddef>
-#include <cstdint>
 #include <functional>
-#include <iterator>
 #include <map>
 #include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -140,44 +136,6 @@ void getAssemblyLocationCode(
 
             assemblyData["Location"]["PartLocation"]["ServiceLabel"] = value;
         });
-}
-
-inline void afterGetReadyToRemoveOfTodBattery(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    std::size_t assemblyIndex, const boost::system::error_code& ec,
-    const dbus::utility::MapperGetObject& /*unused*/)
-{
-    nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
-    if (ec)
-    {
-        if (ec.value() == boost::system::errc::io_error)
-        {
-            // Battery voltage is not on DBUS so ADCSensor is not
-            // running.
-            nlohmann::json& oemOpenBMC =
-                assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
-            oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
-            oemOpenBMC["ReadyToRemove"] = true;
-            return;
-        }
-        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
-        messages::internalError(asyncResp->res);
-        return;
-    }
-    nlohmann::json& oemOpenBMC =
-        assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
-    oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
-    oemOpenBMC["ReadyToRemove"] = false;
-}
-
-inline void getReadyToRemoveOfTodBattery(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    std::size_t assemblyIndex)
-{
-    dbus::utility::getDbusObject(
-        "/xyz/openbmc_project/sensors/voltage/Battery_Voltage", {},
-        std::bind_front(afterGetReadyToRemoveOfTodBattery, asyncResp,
-                        assemblyIndex));
 }
 
 void getAssemblyPresence(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -408,96 +366,6 @@ inline void handleChassisAssemblyGet(
         });
 }
 
-inline void startOrStopADCSensor(
-    const bool start, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
-{
-    std::string method{"StartUnit"};
-    if (!start)
-    {
-        method = "StopUnit";
-    }
-
-    dbus::utility::async_method_call(
-        [asyncResp](const boost::system::error_code& ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("Failed to start or stop ADCSensor:{}",
-                                 ec.value());
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            messages::success(asyncResp->res);
-        },
-        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
-        "org.freedesktop.systemd1.Manager", method,
-        "xyz.openbmc_project.adcsensor.service", "replace");
-}
-
-inline void afterGetDbusObjectDoBatteryCM(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& assembly, const boost::system::error_code& ec,
-    const dbus::utility::MapperGetObject& object)
-{
-    if (ec)
-    {
-        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
-    for (const auto& [serviceName, interfaceList] : object)
-    {
-        auto ifaceIt = std::ranges::find(
-            interfaceList,
-            "xyz.openbmc_project.State.Decorator.OperationalStatus");
-
-        if (ifaceIt == interfaceList.end())
-        {
-            continue;
-        }
-
-        sdbusplus::asio::setProperty(
-            *crow::connections::systemBus, serviceName, assembly,
-            "xyz.openbmc_project.State.Decorator."
-            "OperationalStatus",
-            "Functional", true,
-            [asyncResp, assembly](const boost::system::error_code& ec2) {
-                if (ec2)
-                {
-                    BMCWEB_LOG_ERROR(
-                        "Failed to set functional property on battery: {} ",
-                        ec2.value());
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                startOrStopADCSensor(true, asyncResp);
-            });
-        return;
-    }
-
-    BMCWEB_LOG_ERROR("No OperationalStatus interface on {}", assembly);
-    messages::internalError(asyncResp->res);
-}
-
-inline void doBatteryCM(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& assembly, const bool readyToRemove)
-{
-    if (readyToRemove)
-    {
-        // Stop the adcsensor service so it doesn't monitor the battery
-        startOrStopADCSensor(false, asyncResp);
-        return;
-    }
-
-    // Find the service that has the OperationalStatus iface, set the
-    // Functional property back to true, and then start the adcsensor service.
-    std::array<std::string_view, 1> interfaces = {
-        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
-    dbus::utility::getDbusObject(
-        assembly, interfaces,
-        std::bind_front(afterGetDbusObjectDoBatteryCM, asyncResp, assembly));
-}
-
 /**
  * @brief Set location indicator for the assemblies associated to given chassis
  * @param[in] req - The request data
@@ -698,187 +566,6 @@ inline void handleChassisAssemblyPatch(
                                           assemblyList);
         });
 }
-
-namespace assembly
-{
-/**
- * @brief API used to fill the Assembly id of the assembled object that
- *        assembled in the given assembly parent object path.
- *
- *        bmcweb using the sequential numeric value by sorting the
- *        assembled objects instead of the assembled object dbus id
- *        for the Redfish Assembly implementation.
- *
- * @param[in] asyncResp - The redfish response to return.
- * @param[in] assemblyParentServ - The assembly parent dbus service name.
- * @param[in] assemblyParentObjPath - The assembly parent dbus object path.
- * @param[in] assemblyParentIface - The assembly parent dbus interface name
- *                                  to valid the supports in the bmcweb.
- * @param[in] assemblyUriPropPath - The redfish property path to fill with id.
- * @param[in] assembledObjPath - The assembled object that need to fill with
- *                               its id. Used to check in the parent assembly
- *                               associations.
- * @param[in] assembledUriVal - The assembled object redfish uri value that
- *                              need to replace with its id.
- *
- * @return The redfish response with assembled object id in the given
- *         redfish property path if success else returns the error.
- */
-inline void fillWithAssemblyId(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& assemblyParentServ,
-    const sdbusplus::message::object_path& assemblyParentObjPath,
-    const std::string& assemblyParentIface,
-    const nlohmann::json::json_pointer& assemblyUriPropPath,
-    const sdbusplus::message::object_path& assembledObjPath,
-    const std::string& assembledUriVal)
-{
-    if (assemblyParentIface != "xyz.openbmc_project.Inventory.Item.Chassis")
-    {
-        // Currently, bmcweb supporting only chassis assembly uri so return
-        // error if unsupported assembly uri interface was given
-        BMCWEB_LOG_ERROR(
-            "Unsupported interface [{}] was given to fill assembly id. Please add support in the bmcweb",
-            assemblyParentIface);
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
-    using associationList =
-        std::vector<std::tuple<std::string, std::string, std::string>>;
-
-    sdbusplus::asio::getProperty<associationList>( //
-        *crow::connections::systemBus, assemblyParentServ,
-        assemblyParentObjPath.str,
-        "xyz.openbmc_project.Association.Definitions", "Associations",
-        [asyncResp, assemblyUriPropPath, assemblyParentObjPath,
-         assembledObjPath,
-         assembledUriVal](const boost::system::error_code& ec,
-                          const associationList& associations) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR(
-                    "DBUS response error [{}  : {}] when tried to get the Associations from [{}] to fill Assembly id of the assembled object [{}]",
-                    ec.value(), ec.message(), assemblyParentObjPath.str,
-                    assembledObjPath.str);
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            std::vector<std::string> assemblyAssoc;
-            for (const auto& association : associations)
-            {
-                if (std::get<0>(association) != "assembly")
-                {
-                    continue;
-                }
-                assemblyAssoc.emplace_back(std::get<2>(association));
-            }
-
-            if (assemblyAssoc.empty())
-            {
-                BMCWEB_LOG_ERROR(
-                    "No assembly associations in the [{}] to fill Assembly id of the assembled object [{}]",
-                    assemblyParentObjPath.str, assembledObjPath.str);
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            // Mak sure whether the retrieved assembly associations are
-            // implemented before finding the assembly id as per bmcweb Assembly
-            // design.
-            dbus::utility::async_method_call(
-                [asyncResp, assemblyUriPropPath, assemblyParentObjPath,
-                 assembledObjPath, assemblyAssoc, assembledUriVal](
-                    const boost::system::error_code& ec1,
-                    const dbus::utility::MapperGetSubTreeResponse& objects) {
-                    if (ec1)
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "DBUS response error [{} : {}] when tried to get the subtree to check assembled objects implementation of the [{}] to find assembled object id of the [{}] to fill in the URI property",
-                            ec1.value(), ec1.message(),
-                            assemblyParentObjPath.str, assembledObjPath.str);
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    if (objects.empty())
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "No objects in the [{}] to check assembled objects implementation to fill the assembled object [{}] id in the URI property",
-                            assemblyParentObjPath.str, assembledObjPath.str);
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    std::vector<std::string> implAssemblyAssocs;
-                    for (const auto& object : objects)
-                    {
-                        auto it =
-                            std::ranges::find(assemblyAssoc, object.first);
-                        if (it != assemblyAssoc.end())
-                        {
-                            implAssemblyAssocs.emplace_back(*it);
-                        }
-                    }
-
-                    if (implAssemblyAssocs.empty())
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "The assembled objects of the [{}] are not implemented so unable to fill the assembled object [{}] id in the URI property",
-                            assemblyParentObjPath.str, assembledObjPath.str);
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    // sort  the implemented assemply object as per bmcweb
-                    // design to match with Assembly GET and PATCH handler.
-                    std::ranges::sort(implAssemblyAssocs);
-
-                    auto assembledObjectIt = std::ranges::find(
-                        implAssemblyAssocs, assembledObjPath.str);
-
-                    if (assembledObjectIt == implAssemblyAssocs.end())
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "The assembled object [{}] in the object [{}] is not implemented so unable to fill assembled object id in the URI property",
-                            assembledObjPath.str, assemblyParentObjPath.str);
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    auto assembledObjectId = std::distance(
-                        implAssemblyAssocs.begin(), assembledObjectIt);
-
-                    std::string::size_type assembledObjectNamePos =
-                        assembledUriVal.rfind(assembledObjPath.filename());
-
-                    if (assembledObjectNamePos == std::string::npos)
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "The assembled object name [{}] is not found in the redfish property value [{}] to replace with assembled object id [{}]",
-                            assembledObjPath.filename(), assembledUriVal,
-                            assembledObjectId);
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-                    std::string uriValwithId(assembledUriVal);
-                    uriValwithId.replace(assembledObjectNamePos,
-                                         assembledObjPath.filename().length(),
-                                         std::to_string(assembledObjectId));
-
-                    asyncResp->res.jsonValue[assemblyUriPropPath] =
-                        uriValwithId;
-                },
-                "xyz.openbmc_project.ObjectMapper",
-                "/xyz/openbmc_project/object_mapper",
-                "xyz.openbmc_project.ObjectMapper", "GetSubTree",
-                "/xyz/openbmc_project/inventory", int32_t(0),
-                chassisAssemblyInterfaces);
-        });
-}
-
-} // namespace assembly
 
 /**
  * Systems derived class for delivering Assembly Schema.

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -17,7 +17,6 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/assembly_utils.hpp"
 #include "utils/asset_utils.hpp"
-#include "utils/chassis_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
 
@@ -247,6 +246,13 @@ inline void getAssemblyProperties(
             std::bind_front(afterGetDbusObject, asyncResp, assembly,
                             assemblyJsonPtr));
 
+        getLocationIndicatorActive(
+            asyncResp, assembly, [asyncResp, assemblyJsonPtr](bool asserted) {
+                asyncResp->res
+                    .jsonValue[assemblyJsonPtr]["LocationIndicatorActive"] =
+                    asserted;
+            });
+
         nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
         asyncResp->res.jsonValue["Assemblies@odata.count"] =
             assemblyArray.size();
@@ -337,49 +343,31 @@ inline void handleChassisAssemblyHead(
         });
 }
 
-/**
- * @brief Set location indicator for the assemblies associated to given chassis
- * @param[in] req - The request data
- * @param[in] asyncResp - Shared pointer for asynchronous calls.
- * @param[in] chassisID - Chassis the assemblies are associated with.
- * @param[in] assemblies - list of all the assemblies associated with the
- * chassis.
-
- * @return None.
- */
-inline void setAssemblyLocationIndicators(
-    const crow::Request& req,
+inline void afterHandleChassisAssemblyPatch(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisID, const std::vector<std::string>& assemblies)
+    const std::string& chassisID,
+    std::vector<nlohmann::json::object_t>& assemblyData,
+    const boost::system::error_code& ec,
+    const std::vector<std::string>& assemblyList)
 {
-    BMCWEB_LOG_DEBUG(
-        "Set LocationIndicatorActive for assembly associated to chassis = {}",
-        chassisID);
-
-    std::optional<std::vector<nlohmann::json>> assemblyData;
-    if (!json_util::readJsonAction(req, asyncResp->res, "Assemblies",
-                                   assemblyData))
+    if (ec)
     {
-        return;
-    }
-    if (!assemblyData)
-    {
+        BMCWEB_LOG_WARNING("Chassis {} not found", chassisID);
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisID);
         return;
     }
 
-    std::vector<nlohmann::json> items = std::move(*assemblyData);
     std::map<std::string, bool> locationIndicatorActiveMap;
     std::map<std::string, nlohmann::json> oemIndicatorMap;
 
-    for (auto& item : items)
+    for (nlohmann::json::object_t& item : assemblyData)
     {
         std::optional<std::string> memberId;
         std::optional<bool> locationIndicatorActive;
         std::optional<nlohmann::json> oem;
-
-        if (!json_util::readJson(
-                item, asyncResp->res, "LocationIndicatorActive",
-                locationIndicatorActive, "MemberId", memberId, "Oem", oem))
+        if (!json_util::readJsonObject(item, asyncResp->res, "MemberId",
+                                       memberId, "LocationIndicatorActive",
+                                       locationIndicatorActive, "Oem", oem))
         {
             return;
         }
@@ -415,7 +403,7 @@ inline void setAssemblyLocationIndicators(
     }
 
     std::size_t assemblyIndex = 0;
-    for (const auto& assembly : assemblies)
+    for (const auto& assembly : assemblyList)
     {
         auto iter =
             locationIndicatorActiveMap.find(std::to_string(assemblyIndex));
@@ -481,12 +469,12 @@ inline void setAssemblyLocationIndicators(
                 }
 
                 dbus::utility::async_method_call(
-                    [asyncResp, action](const boost::system::error_code& ec) {
-                        if (ec)
+                    [asyncResp, action](const boost::system::error_code& ec1) {
+                        if (ec1)
                         {
                             BMCWEB_LOG_ERROR(
                                 "Call to Manager failed for action: {} with error: {}",
-                                action, ec.value());
+                                action, ec1.value());
                             messages::internalError(asyncResp->res);
                             return;
                         }
@@ -518,24 +506,17 @@ inline void handleChassisAssemblyPatch(
         return;
     }
 
-    BMCWEB_LOG_DEBUG("Patch chassis path");
+    std::vector<nlohmann::json::object_t> assemblyData;
+    if (!redfish::json_util::readJsonPatch(req, asyncResp->res, "Assemblies",
+                                           assemblyData))
+    {
+        return;
+    }
 
-    chassis_utils::getChassisAssembly(
+    assembly_utils::getChassisAssembly(
         asyncResp, chassisID,
-        [req = std::make_shared<crow::Request>(req.copy()), asyncResp,
-         chassisID](const std::optional<std::string>& validChassisPath,
-                    const std::vector<std::string>& assemblyList) {
-            if (!validChassisPath || assemblyList.empty())
-            {
-                BMCWEB_LOG_WARNING("Chassis not found");
-                messages::resourceNotFound(asyncResp->res, "Chassis",
-                                           chassisID);
-                return;
-            }
-
-            setAssemblyLocationIndicators(*req, asyncResp, chassisID,
-                                          assemblyList);
-        });
+        std::bind_front(afterHandleChassisAssemblyPatch, asyncResp, chassisID,
+                        assemblyData));
 }
 
 /**

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
 
 #include "app.hpp"
@@ -13,17 +15,20 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/assembly_utils.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
-#include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
 
+#include <asm-generic/errno.h>
+
+#include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
 #include <sdbusplus/asio/property.hpp>
-#include <sdbusplus/unpack_properties.hpp>
 
 #include <cstddef>
 #include <functional>
@@ -40,209 +45,192 @@ namespace redfish
 {
 
 /**
- * @brief Get Asset properties on the given assembly.
- * @param[in] asyncResp - Shared pointer for asynchronous calls.
- * @param[in] serviceName - Service in which the assembly is hosted.
- * @param[in] assembly - Assembly object.
- * @param[in] assemblyIndex - Index on the assembly object.
- * @return None.
- */
-void getAssemblyAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                      const auto& serviceName, const auto& assembly,
-                      const auto& assemblyIndex)
-{
-    sdbusplus::asio::getAllProperties(
-        *crow::connections::systemBus, serviceName, assembly,
-        "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [asyncResp, assemblyIndex](
-            const boost::system::error_code& ec1,
-            const dbus::utility::DBusPropertiesMap& propertiesList) {
-            if (ec1)
-            {
-                BMCWEB_LOG_ERROR("DBUS response error {}", ec1.value());
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            const std::string* partNumber = nullptr;
-            const std::string* serialNumber = nullptr;
-            const std::string* sparePartNumber = nullptr;
-            const std::string* model = nullptr;
-
-            const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-                partNumber, "SerialNumber", serialNumber, "SparePartNumber",
-                sparePartNumber, "Model", model);
-
-            if (!success)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            nlohmann::json& assemblyArray =
-                asyncResp->res.jsonValue["Assemblies"];
-            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-
-            if (partNumber != nullptr)
-            {
-                assemblyData["PartNumber"] = *partNumber;
-            }
-
-            if (serialNumber != nullptr)
-            {
-                assemblyData["SerialNumber"] = *serialNumber;
-            }
-
-            if (sparePartNumber != nullptr)
-            {
-                assemblyData["SparePartNumber"] = *sparePartNumber;
-            }
-
-            if (model != nullptr)
-            {
-                assemblyData["Model"] = *model;
-            }
-        });
-}
-
-/**
  * @brief Get Location code for the given assembly.
  * @param[in] asyncResp - Shared pointer for asynchronous calls.
  * @param[in] serviceName - Service in which the assembly is hosted.
  * @param[in] assembly - Assembly object.
- * @param[in] assemblyIndex - Index on the assembly object.
+ * @param[in] assemblyJsonPtr - json-keyname on the assembly list output.
  * @return None.
  */
-void getAssemblyLocationCode(
+inline void getAssemblyLocationCode(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const auto& serviceName, const auto& assembly, const auto& assemblyIndex)
+    const std::string& serviceName, const std::string& assembly,
+    const nlohmann::json::json_pointer& assemblyJsonPtr)
 {
     sdbusplus::asio::getProperty<std::string>(
         *crow::connections::systemBus, serviceName, assembly,
         "xyz.openbmc_project.Inventory.Decorator.LocationCode", "LocationCode",
-        [asyncResp, assemblyIndex](const boost::system::error_code& ec1,
-                                   const std::string& value) {
-            if (ec1)
+        [asyncResp, assembly, assemblyJsonPtr](
+            const boost::system::error_code& ec, const std::string& value) {
+            if (ec)
             {
-                BMCWEB_LOG_ERROR("DBUS response error: {}", ec1.value());
-                messages::internalError(asyncResp->res);
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error: {} for assembly {}",
+                                     ec.value(), assembly);
+                    messages::internalError(asyncResp->res);
+                }
                 return;
             }
 
-            nlohmann::json& assemblyArray =
-                asyncResp->res.jsonValue["Assemblies"];
-            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-
-            assemblyData["Location"]["PartLocation"]["ServiceLabel"] = value;
+            asyncResp->res.jsonValue[assemblyJsonPtr]["Location"]
+                                    ["PartLocation"]["ServiceLabel"] = value;
         });
 }
 
-void getAssemblyPresence(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                         const auto& serviceName, const auto& assembly,
-                         const auto& assemblyIndex)
+inline void getAssemblyState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const auto& serviceName, const auto& assembly,
+    const nlohmann::json::json_pointer& assemblyJsonPtr)
 {
-    nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
-    nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-
-    assemblyData["Status"]["State"] = resource::State::Enabled;
+    asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["State"] =
+        resource::State::Enabled;
 
     dbus::utility::getProperty<bool>(
         serviceName, assembly, "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp, assemblyIndex,
+        [asyncResp, assemblyJsonPtr,
          assembly](const boost::system::error_code& ec, const bool value) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
-                messages::internalError(asyncResp->res);
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                    messages::internalError(asyncResp->res);
+                }
                 return;
             }
 
-            nlohmann::json& array = asyncResp->res.jsonValue["Assemblies"];
-            nlohmann::json& data = array.at(assemblyIndex);
-            std::string fru =
-                sdbusplus::message::object_path(assembly).filename();
-
             if (!value)
             {
-                data["Status"]["State"] = resource::State::Absent;
+                asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["State"] =
+                    resource::State::Absent;
             }
 
+            std::string fru =
+                sdbusplus::message::object_path(assembly).filename();
             // Special handling for LCD and base panel CM.
             if (fru == "panel0" || fru == "panel1")
             {
-                data["Oem"]["OpenBMC"]["@odata.type"] =
+                asyncResp->res.jsonValue[assemblyJsonPtr]["Oem"]["OpenBMC"]
+                                        ["@odata.type"] =
                     "#OpenBMCAssembly.v1_0_0.OpenBMC";
 
                 // if panel is not present, implies it is already removed or
                 // can be placed.
-                data["Oem"]["OpenBMC"]["ReadyToRemove"] = !value;
+                asyncResp->res.jsonValue[assemblyJsonPtr]["Oem"]["OpenBMC"]
+                                        ["ReadyToRemove"] = !value;
             }
         });
 }
 
-void getAssemblyHeath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                      const auto& serviceName, const auto& assembly,
-                      const auto& assemblyIndex)
+void getAssemblyHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                       const auto& serviceName, const auto& assembly,
+                       const nlohmann::json::json_pointer& assemblyJsonPtr)
 {
+    asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["Health"] =
+        resource::Health::OK;
+
     dbus::utility::getProperty<bool>(
         serviceName, assembly,
         "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp,
-         assemblyIndex](const boost::system::error_code& ec, bool functional) {
+        [asyncResp, assemblyJsonPtr](const boost::system::error_code& ec,
+                                     bool functional) {
             if (ec)
             {
-                BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
-                messages::internalError(asyncResp->res);
+                if (ec.value() != EBADR)
+                {
+                    BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+                    messages::internalError(asyncResp->res);
+                }
                 return;
             }
 
-            nlohmann::json& assemblyArray =
-                asyncResp->res.jsonValue["Assemblies"];
-            nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-
-            assemblyData["Status"]["Health"] = resource::Health::OK;
             if (!functional)
             {
-                assemblyData["Status"]["Health"] = resource::Health::Critical;
+                asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["Health"] =
+                    resource::Health::Critical;
             }
         });
+}
+
+inline void afterGetDbusObject(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& assembly,
+    const nlohmann::json::json_pointer& assemblyJsonPtr,
+    const boost::system::error_code& ec,
+    const dbus::utility::MapperGetObject& object)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error : {} for assembly {}", ec.value(),
+                         assembly);
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    nlohmann::json::json_pointer ptr = assemblyJsonPtr;
+    ptr /= "Name";
+    name_util::getPrettyName(asyncResp, assembly, object, ptr);
+
+    for (const auto& [serviceName, interfaceList] : object)
+    {
+        for (const auto& interface : interfaceList)
+        {
+            if (interface == "xyz.openbmc_project.Inventory.Decorator.Asset")
+            {
+                asset_utils::getAssetInfo(asyncResp, serviceName, assembly,
+                                          assemblyJsonPtr, true, false);
+            }
+            else if (interface ==
+                     "xyz.openbmc_project.Inventory.Decorator.LocationCode")
+            {
+                getAssemblyLocationCode(asyncResp, serviceName, assembly,
+                                        assemblyJsonPtr);
+            }
+            else if (interface == "xyz.openbmc_project.Inventory.Item")
+            {
+                getAssemblyState(asyncResp, serviceName, assembly,
+                                 assemblyJsonPtr);
+            }
+            else if (interface ==
+                     "xyz.openbmc_project.State.Decorator.OperationalStatus")
+            {
+                getAssemblyHealth(asyncResp, serviceName, assembly,
+                                  assemblyJsonPtr);
+            }
+        }
+    }
 }
 
 /**
  * @brief Get properties for the assemblies associated to given chassis
  * @param[in] asyncResp - Shared pointer for asynchronous calls.
- * @param[in] chassisPath - Chassis the assemblies are associated with.
+ * @param[in] chassisId - Chassis the assemblies are associated with.
  * @param[in] assemblies - list of all the assemblies associated with the
  * chassis.
  * @return None.
  */
 inline void getAssemblyProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisPath, const std::vector<std::string>& assemblies)
+    const std::string& chassisId, const std::vector<std::string>& assemblies)
 {
     BMCWEB_LOG_DEBUG("Get properties for assembly associated");
 
-    const std::string& chassis =
-        sdbusplus::message::object_path(chassisPath).filename();
-
     std::size_t assemblyIndex = 0;
-
-    for (const auto& assembly : assemblies)
+    for (const std::string& assembly : assemblies)
     {
-        nlohmann::json& tempArray = asyncResp->res.jsonValue["Assemblies"];
-
         nlohmann::json::object_t item;
-        item["@odata.type"] = "#Assembly.v1_3_0.AssemblyData";
+        item["@odata.type"] = "#Assembly.v1_5_1.AssemblyData";
         item["@odata.id"] = boost::urls::format(
-            "/redfish/v1/Chassis/{}/Assembly#/Assemblies/{}", chassis,
+            "/redfish/v1/Chassis/{}/Assembly#/Assemblies/{}", chassisId,
             std::to_string(assemblyIndex));
         item["MemberId"] = std::to_string(assemblyIndex);
+        item["Name"] = sdbusplus::message::object_path(assembly).filename();
 
-        tempArray.emplace_back(item);
+        asyncResp->res.jsonValue["Assemblies"].emplace_back(item);
 
-        tempArray.at(assemblyIndex)["Name"] =
-            sdbusplus::message::object_path(assembly).filename();
+        nlohmann::json::json_pointer assemblyJsonPtr(
+            "/Assemblies/" + std::to_string(assemblyIndex));
 
         // Handle special case for tod_battery assembly OEM ReadyToRemove
         // property NOTE: The following method for the special case of the
@@ -255,62 +243,9 @@ inline void getAssemblyProperties(
         }
 
         dbus::utility::getDbusObject(
-            assembly, chassisAssemblyInterfaces,
-            [asyncResp, assemblyIndex,
-             assembly](const boost::system::error_code& ec,
-                       const dbus::utility::MapperGetObject& object) {
-                if (ec)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error : {}", ec.value());
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-
-                nlohmann::json::json_pointer ptr(
-                    "/Assemblies/" + std::to_string(assemblyIndex) + "/Name");
-                name_util::getPrettyName(asyncResp, assembly, object, ptr);
-
-                for (const auto& [serviceName, interfaceList] : object)
-                {
-                    for (const auto& interface : interfaceList)
-                    {
-                        if (interface ==
-                            "xyz.openbmc_project.Inventory.Decorator.Asset")
-                        {
-                            getAssemblyAsset(asyncResp, serviceName, assembly,
-                                             assemblyIndex);
-                        }
-                        else if (
-                            interface ==
-                            "xyz.openbmc_project.Inventory.Decorator.LocationCode")
-                        {
-                            getAssemblyLocationCode(asyncResp, serviceName,
-                                                    assembly, assemblyIndex);
-                        }
-                        else if (interface ==
-                                 "xyz.openbmc_project.Inventory.Item")
-                        {
-                            getAssemblyPresence(asyncResp, serviceName,
-                                                assembly, assemblyIndex);
-                        }
-                        else if (
-                            interface ==
-                            "xyz.openbmc_project.State.Decorator.OperationalStatus")
-                        {
-                            getAssemblyHeath(asyncResp, serviceName, assembly,
-                                             assemblyIndex);
-                        }
-                    }
-                }
-            });
-
-        getLocationIndicatorActive(
-            asyncResp, assembly, [asyncResp, assemblyIndex](bool asserted) {
-                nlohmann::json& assemblyArray =
-                    asyncResp->res.jsonValue["Assemblies"];
-                nlohmann::json& assemblyData = assemblyArray.at(assemblyIndex);
-                assemblyData["LocationIndicatorActive"] = asserted;
-            });
+            assembly, assemblyInterfaces,
+            std::bind_front(afterGetDbusObject, asyncResp, assembly,
+                            assemblyJsonPtr));
 
         nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
         asyncResp->res.jsonValue["Assemblies@odata.count"] =
@@ -320,8 +255,38 @@ inline void getAssemblyProperties(
     }
 }
 
+inline void afterHandleChassisAssemblyGet(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID, const boost::system::error_code& ec,
+    const std::vector<std::string>& assemblyList)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_WARNING("Chassis {} not found", chassisID);
+        messages::resourceNotFound(asyncResp->res, "Chassis", chassisID);
+        return;
+    }
+
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/Assembly/Assembly.json>; rel=describedby");
+
+    asyncResp->res.jsonValue["@odata.type"] = "#Assembly.v1_5_1.Assembly";
+    asyncResp->res.jsonValue["@odata.id"] =
+        boost::urls::format("/redfish/v1/Chassis/{}/Assembly", chassisID);
+    asyncResp->res.jsonValue["Name"] = "Assembly Collection";
+    asyncResp->res.jsonValue["Id"] = "Assembly";
+
+    asyncResp->res.jsonValue["Assemblies"] = nlohmann::json::array();
+    asyncResp->res.jsonValue["Assemblies@odata.count"] = 0;
+
+    if (!assemblyList.empty())
+    {
+        getAssemblyProperties(asyncResp, chassisID, assemblyList);
+    }
+}
+
 /**
- * @brief Get chassis path with given chassis ID
  * @param[in] asyncResp - Shared pointer for asynchronous calls.
  * @param[in] chassisID - Chassis to which the assemblies are
  * associated.
@@ -329,40 +294,46 @@ inline void getAssemblyProperties(
  * @return None.
  */
 inline void handleChassisAssemblyGet(
-    App& /*unused*/, const crow::Request& /*unused*/,
+    App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisID)
 {
-    BMCWEB_LOG_DEBUG("Get chassis path");
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
 
-    chassis_utils::getChassisAssembly(
+    BMCWEB_LOG_DEBUG("Get chassis Assembly");
+    assembly_utils::getChassisAssembly(
+        asyncResp, chassisID,
+        std::bind_front(afterHandleChassisAssemblyGet, asyncResp, chassisID));
+}
+
+inline void handleChassisAssemblyHead(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& chassisID)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    assembly_utils::getChassisAssembly(
         asyncResp, chassisID,
         [asyncResp,
-         chassisID](const std::optional<std::string>& validChassisPath,
-                    const std::vector<std::string>& assemblyList) {
-            if (!validChassisPath)
+         chassisID](const boost::system::error_code& ec,
+                    const std::vector<std::string>& /*assemblyList*/) {
+            if (ec)
             {
-                BMCWEB_LOG_WARNING("Chassis not found");
+                BMCWEB_LOG_WARNING("Chassis {} not found", chassisID);
                 messages::resourceNotFound(asyncResp->res, "Chassis",
                                            chassisID);
                 return;
             }
-            const std::string& chassisPath = *validChassisPath;
-
-            asyncResp->res.jsonValue["@odata.type"] =
-                "#Assembly.v1_3_0.Assembly";
-            asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
-                "/redfish/v1/Chassis/{}/Assembly", chassisID);
-            asyncResp->res.jsonValue["Name"] = "Assembly Collection";
-            asyncResp->res.jsonValue["Id"] = "Assembly";
-
-            asyncResp->res.jsonValue["Assemblies"] = nlohmann::json::array();
-            asyncResp->res.jsonValue["Assemblies@odata.count"] = 0;
-
-            if (!assemblyList.empty())
-            {
-                getAssemblyProperties(asyncResp, chassisPath, assemblyList);
-            }
+            asyncResp->res.addHeader(
+                boost::beast::http::field::link,
+                "</redfish/v1/JsonSchemas/Assembly.json>; rel=describedby");
         });
 }
 
@@ -572,9 +543,11 @@ inline void handleChassisAssemblyPatch(
  */
 inline void requestRoutesAssembly(App& app)
 {
-    /**
-     * Functions triggers appropriate requests on DBus
-     */
+    BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Assembly/")
+        .privileges(redfish::privileges::headAssembly)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handleChassisAssemblyHead, std::ref(app)));
+
     BMCWEB_ROUTE(app, "/redfish/v1/Chassis/<str>/Assembly/")
         .privileges(redfish::privileges::getAssembly)
         .methods(boost::beast::http::verb::get)(
@@ -585,4 +558,5 @@ inline void requestRoutesAssembly(App& app)
         .methods(boost::beast::http::verb::patch)(
             std::bind_front(handleChassisAssemblyPatch, std::ref(app)));
 }
+
 } // namespace redfish

--- a/redfish-core/lib/assembly_battery_cm.hpp
+++ b/redfish-core/lib/assembly_battery_cm.hpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "http_response.hpp"
+#include "logging.hpp"
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+
+namespace redfish
+{
+
+inline void afterGetReadyToRemoveOfTodBattery(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::size_t assemblyIndex, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetObject& /*unused*/)
+{
+    nlohmann::json& assemblyArray = asyncResp->res.jsonValue["Assemblies"];
+    if (ec)
+    {
+        if (ec.value() == boost::system::errc::io_error)
+        {
+            // Battery voltage is not on DBUS so ADCSensor is not
+            // running.
+            nlohmann::json& oemOpenBMC =
+                assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
+            oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
+            oemOpenBMC["ReadyToRemove"] = true;
+            return;
+        }
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    nlohmann::json& oemOpenBMC =
+        assemblyArray.at(assemblyIndex)["Oem"]["OpenBMC"];
+    oemOpenBMC["@odata.type"] = "#OpenBMCAssembly.v1_0_0.OpenBMC";
+    oemOpenBMC["ReadyToRemove"] = false;
+}
+
+inline void getReadyToRemoveOfTodBattery(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    std::size_t assemblyIndex)
+{
+    dbus::utility::getDbusObject(
+        "/xyz/openbmc_project/sensors/voltage/Battery_Voltage", {},
+        std::bind_front(afterGetReadyToRemoveOfTodBattery, asyncResp,
+                        assemblyIndex));
+}
+
+inline void startOrStopADCSensor(
+    const bool start, const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    std::string method{"StartUnit"};
+    if (!start)
+    {
+        method = "StopUnit";
+    }
+
+    dbus::utility::async_method_call(
+        [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR("Failed to start or stop ADCSensor:{}",
+                                 ec.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        },
+        "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager", method,
+        "xyz.openbmc_project.adcsensor.service", "replace");
+}
+
+inline void afterGetDbusObjectDoBatteryCM(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& assembly, const boost::system::error_code& ec,
+    const dbus::utility::MapperGetObject& object)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    for (const auto& [serviceName, interfaceList] : object)
+    {
+        auto ifaceIt = std::ranges::find(
+            interfaceList,
+            "xyz.openbmc_project.State.Decorator.OperationalStatus");
+
+        if (ifaceIt == interfaceList.end())
+        {
+            continue;
+        }
+
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, serviceName, assembly,
+            "xyz.openbmc_project.State.Decorator."
+            "OperationalStatus",
+            "Functional", true,
+            [asyncResp, assembly](const boost::system::error_code& ec2) {
+                if (ec2)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "Failed to set functional property on battery: {} ",
+                        ec2.value());
+                    messages::internalError(asyncResp->res);
+                    return;
+                }
+                startOrStopADCSensor(true, asyncResp);
+            });
+        return;
+    }
+
+    BMCWEB_LOG_ERROR("No OperationalStatus interface on {}", assembly);
+    messages::internalError(asyncResp->res);
+}
+
+inline void doBatteryCM(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                        const std::string& assembly, const bool readyToRemove)
+{
+    if (readyToRemove)
+    {
+        // Stop the adcsensor service so it doesn't monitor the battery
+        startOrStopADCSensor(false, asyncResp);
+        return;
+    }
+
+    // Find the service that has the OperationalStatus iface, set the
+    // Functional property back to true, and then start the adcsensor service.
+    std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
+    dbus::utility::getDbusObject(
+        assembly, interfaces,
+        std::bind_front(afterGetDbusObjectDoBatteryCM, asyncResp, assembly));
+}
+
+} // namespace redfish

--- a/redfish-core/lib/chassis.hpp
+++ b/redfish-core/lib/chassis.hpp
@@ -19,6 +19,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
@@ -318,49 +319,8 @@ inline void handleDecoratorAssetProperties(
     const std::string& chassisId, const std::string& path,
     const dbus::utility::DBusPropertiesMap& propertiesList)
 {
-    const std::string* partNumber = nullptr;
-    const std::string* serialNumber = nullptr;
-    const std::string* manufacturer = nullptr;
-    const std::string* model = nullptr;
-    const std::string* sparePartNumber = nullptr;
-
-    const bool success = sdbusplus::unpackPropertiesNoThrow(
-        dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-        partNumber, "SerialNumber", serialNumber, "Manufacturer", manufacturer,
-        "Model", model, "SparePartNumber", sparePartNumber);
-
-    if (!success)
-    {
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
-    if (partNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-    }
-
-    if (serialNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-    }
-
-    if (manufacturer != nullptr)
-    {
-        asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-    }
-
-    if (model != nullptr)
-    {
-        asyncResp->res.jsonValue["Model"] = *model;
-    }
-
-    // SparePartNumber is optional on D-Bus
-    // so skip if it is empty
-    if (sparePartNumber != nullptr && !sparePartNumber->empty())
-    {
-        asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
-    }
+    asset_utils::extractAssetInfo(asyncResp, ""_json_pointer, propertiesList,
+                                  true);
 
     asyncResp->res.jsonValue["Name"] = chassisId;
     asyncResp->res.jsonValue["Id"] = chassisId;

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -14,9 +14,9 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
-#include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
 
@@ -27,7 +27,6 @@
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <sdbusplus/message/native_types.hpp>
-#include <sdbusplus/unpack_properties.hpp>
 
 #include <algorithm>
 #include <array>
@@ -63,64 +62,6 @@ inline void getFabricAdapterLocation(
             asyncResp->res
                 .jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
                 property;
-        });
-}
-
-inline void getFabricAdapterAsset(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& serviceName, const std::string& fabricAdapterPath)
-{
-    dbus::utility::getAllProperties(
-        serviceName, fabricAdapterPath,
-        "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [fabricAdapterPath, asyncResp{asyncResp}](
-            const boost::system::error_code& ec,
-            const dbus::utility::DBusPropertiesMap& propertiesList) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Properties");
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            const std::string* serialNumber = nullptr;
-            const std::string* model = nullptr;
-            const std::string* partNumber = nullptr;
-            const std::string* sparePartNumber = nullptr;
-
-            const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), propertiesList,
-                "SerialNumber", serialNumber, "Model", model, "PartNumber",
-                partNumber, "SparePartNumber", sparePartNumber);
-
-            if (!success)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (serialNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-            }
-
-            if (model != nullptr)
-            {
-                asyncResp->res.jsonValue["Model"] = *model;
-            }
-
-            if (partNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-            }
-
-            if (sparePartNumber != nullptr && !sparePartNumber->empty())
-            {
-                asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
-            }
         });
 }
 
@@ -338,7 +279,8 @@ inline void doAdapterGet(
         });
 
     getFabricAdapterLocation(asyncResp, serviceName, fabricAdapterPath);
-    getFabricAdapterAsset(asyncResp, serviceName, fabricAdapterPath);
+    asset_utils::getAssetInfo(asyncResp, serviceName, fabricAdapterPath,
+                              ""_json_pointer, true);
     getFabricAdapterState(asyncResp, serviceName, fabricAdapterPath);
     getFabricAdapterHealth(asyncResp, serviceName, fabricAdapterPath);
     getLocationIndicatorActive(asyncResp, fabricAdapterPath);

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -12,8 +12,8 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
-#include "utils/dbus_utils.hpp"
 #include "utils/fan_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
@@ -25,7 +25,6 @@
 #include <boost/system/error_code.hpp>
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
-#include <sdbusplus/unpack_properties.hpp>
 
 #include <functional>
 #include <memory>
@@ -284,63 +283,6 @@ inline void getFanState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         });
 }
 
-inline void getFanAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& fanPath, const std::string& service)
-{
-    dbus::utility::getAllProperties(
-        service, fanPath, "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [fanPath, asyncResp{asyncResp}](
-            const boost::system::error_code& ec,
-            const dbus::utility::DBusPropertiesMap& assetList) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Properties{}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-            const std::string* manufacturer = nullptr;
-            const std::string* model = nullptr;
-            const std::string* partNumber = nullptr;
-            const std::string* serialNumber = nullptr;
-            const std::string* sparePartNumber = nullptr;
-
-            const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), assetList, "Manufacturer",
-                manufacturer, "Model", model, "PartNumber", partNumber,
-                "SerialNumber", serialNumber, "SparePartNumber",
-                sparePartNumber);
-            if (!success)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-            if (manufacturer != nullptr)
-            {
-                asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-            }
-            if (model != nullptr)
-            {
-                asyncResp->res.jsonValue["Model"] = *model;
-            }
-            if (partNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-            }
-            if (serialNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-            }
-            if (sparePartNumber != nullptr && !sparePartNumber->empty())
-            {
-                asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
-            }
-        });
-}
-
 inline void getFanLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                            const std::string& fanPath,
                            const std::string& service)
@@ -374,7 +316,8 @@ inline void afterGetValidFanObject(
     addFanCommonProperties(asyncResp->res, chassisId, fanId);
     getFanState(asyncResp, fanPath, service);
     getFanHealth(asyncResp, fanPath, service);
-    getFanAsset(asyncResp, fanPath, service);
+    asset_utils::getAssetInfo(asyncResp, service, fanPath, ""_json_pointer,
+                              true);
     getFanLocation(asyncResp, fanPath, service);
     getLocationIndicatorActive(asyncResp, fanPath);
     name_util::getPrettyName(asyncResp, fanPath, service, "/Name"_json_pointer);

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -18,6 +18,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
@@ -471,71 +472,6 @@ inline void afterGetPCIeDeviceSlotPath(
         });
 }
 
-inline void getPCIeDeviceAsset(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& pcieDevicePath, const std::string& service)
-{
-    dbus::utility::getAllProperties(
-        service, pcieDevicePath,
-        "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [pcieDevicePath, asyncResp{asyncResp}](
-            const boost::system::error_code& ec,
-            const dbus::utility::DBusPropertiesMap& assetList) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Properties{}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            const std::string* manufacturer = nullptr;
-            const std::string* model = nullptr;
-            const std::string* partNumber = nullptr;
-            const std::string* serialNumber = nullptr;
-            const std::string* sparePartNumber = nullptr;
-
-            const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), assetList, "Manufacturer",
-                manufacturer, "Model", model, "PartNumber", partNumber,
-                "SerialNumber", serialNumber, "SparePartNumber",
-                sparePartNumber);
-
-            if (!success)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (manufacturer != nullptr)
-            {
-                asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-            }
-            if (model != nullptr)
-            {
-                asyncResp->res.jsonValue["Model"] = *model;
-            }
-
-            if (partNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-            }
-
-            if (serialNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-            }
-
-            if (sparePartNumber != nullptr && !sparePartNumber->empty())
-            {
-                asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
-            }
-        });
-}
-
 inline void getPCIeDeviceLocation(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& pcieDevicePath, const std::string& service)
@@ -707,7 +643,8 @@ inline void afterGetValidPcieDevicePath(
     const std::string& service)
 {
     addPCIeDeviceCommonProperties(asyncResp, pcieDeviceId);
-    getPCIeDeviceAsset(asyncResp, pcieDevicePath, service);
+    asset_utils::getAssetInfo(asyncResp, service, pcieDevicePath,
+                              ""_json_pointer, true);
     getPCIeDeviceProperties(
         asyncResp, pcieDevicePath, service,
         std::bind_front(addPCIeDeviceProperties, asyncResp, pcieDeviceId));

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -12,6 +12,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
@@ -310,49 +311,18 @@ inline void getPowerSupplyAsset(
                 return;
             }
 
-            const std::string* partNumber = nullptr;
-            const std::string* serialNumber = nullptr;
-            const std::string* manufacturer = nullptr;
-            const std::string* model = nullptr;
-            const std::string* sparePartNumber = nullptr;
+            asset_utils::extractAssetInfo(asyncResp, ""_json_pointer,
+                                          propertiesList, true);
+
             const std::string* buildDate = nullptr;
 
             const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-                partNumber, "SerialNumber", serialNumber, "Manufacturer",
-                manufacturer, "Model", model, "SparePartNumber",
-                sparePartNumber, "BuildDate", buildDate);
-
+                dbus_utils::UnpackErrorPrinter(), propertiesList, "BuildDate",
+                buildDate);
             if (!success)
             {
                 messages::internalError(asyncResp->res);
                 return;
-            }
-
-            if (partNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-            }
-
-            if (serialNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-            }
-
-            if (manufacturer != nullptr)
-            {
-                asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-            }
-
-            if (model != nullptr)
-            {
-                asyncResp->res.jsonValue["Model"] = *model;
-            }
-
-            // SparePartNumber is optional on D-Bus so skip if it is empty
-            if (sparePartNumber != nullptr && !sparePartNumber->empty())
-            {
-                asyncResp->res.jsonValue["SparePartNumber"] = *sparePartNumber;
             }
 
             if (buildDate != nullptr)

--- a/redfish-core/lib/storage.hpp
+++ b/redfish-core/lib/storage.hpp
@@ -18,9 +18,9 @@
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
-#include "utils/dbus_utils.hpp"
 #include "utils/name_utils.hpp"
 
 #include <boost/beast/http/verb.hpp>
@@ -28,7 +28,6 @@
 #include <boost/url/format.hpp>
 #include <nlohmann/json.hpp>
 #include <sdbusplus/message/native_types.hpp>
-#include <sdbusplus/unpack_properties.hpp>
 
 #include <algorithm>
 #include <array>
@@ -291,60 +290,6 @@ inline void requestRoutesStorage(App& app)
         .privileges(redfish::privileges::getStorage)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleStorageGet, std::ref(app)));
-}
-
-inline void getDriveAsset(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                          const std::string& connectionName,
-                          const std::string& path)
-{
-    dbus::utility::getAllProperties(
-        connectionName, path, "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [asyncResp](const boost::system::error_code& ec,
-                    const std::vector<
-                        std::pair<std::string, dbus::utility::DbusVariantType>>&
-                        propertiesList) {
-            if (ec)
-            {
-                // this interface isn't necessary
-                return;
-            }
-
-            const std::string* partNumber = nullptr;
-            const std::string* serialNumber = nullptr;
-            const std::string* manufacturer = nullptr;
-            const std::string* model = nullptr;
-
-            const bool success = sdbusplus::unpackPropertiesNoThrow(
-                dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-                partNumber, "SerialNumber", serialNumber, "Manufacturer",
-                manufacturer, "Model", model);
-
-            if (!success)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (partNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-            }
-
-            if (serialNumber != nullptr)
-            {
-                asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-            }
-
-            if (manufacturer != nullptr)
-            {
-                asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-            }
-
-            if (model != nullptr)
-            {
-                asyncResp->res.jsonValue["Model"] = *model;
-            }
-        });
 }
 
 inline void getDrivePresent(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -616,7 +561,8 @@ inline void addAllDriveInfo(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     {
         if (interface == "xyz.openbmc_project.Inventory.Decorator.Asset")
         {
-            getDriveAsset(asyncResp, connectionName, path);
+            asset_utils::getAssetInfo(asyncResp, connectionName, path,
+                                      ""_json_pointer, false);
         }
         else if (interface == "xyz.openbmc_project.Inventory.Item")
         {
@@ -974,53 +920,6 @@ inline void requestRoutesChassisDriveName(App& app)
             std::bind_front(handleChassisDriveGet, std::ref(app)));
 }
 
-inline void getStorageControllerAsset(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const boost::system::error_code& ec,
-    const std::vector<std::pair<std::string, dbus::utility::DbusVariantType>>&
-        propertiesList)
-{
-    if (ec)
-    {
-        // this interface isn't necessary
-        BMCWEB_LOG_DEBUG("Failed to get StorageControllerAsset");
-        return;
-    }
-
-    const std::string* partNumber = nullptr;
-    const std::string* serialNumber = nullptr;
-    const std::string* manufacturer = nullptr;
-    const std::string* model = nullptr;
-    if (!sdbusplus::unpackPropertiesNoThrow(
-            dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-            partNumber, "SerialNumber", serialNumber, "Manufacturer",
-            manufacturer, "Model", model))
-    {
-        messages::internalError(asyncResp->res);
-        return;
-    }
-
-    if (partNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-    }
-
-    if (serialNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-    }
-
-    if (manufacturer != nullptr)
-    {
-        asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-    }
-
-    if (model != nullptr)
-    {
-        asyncResp->res.jsonValue["Model"] = *model;
-    }
-}
-
 inline void populateStorageController(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& controllerId, const std::string& connectionName,
@@ -1052,14 +951,8 @@ inline void populateStorageController(
             }
         });
 
-    dbus::utility::getAllProperties(
-        connectionName, path, "xyz.openbmc_project.Inventory.Decorator.Asset",
-        [asyncResp](const boost::system::error_code& ec,
-                    const std::vector<
-                        std::pair<std::string, dbus::utility::DbusVariantType>>&
-                        propertiesList) {
-            getStorageControllerAsset(asyncResp, ec, propertiesList);
-        });
+    asset_utils::getAssetInfo(asyncResp, connectionName, path, ""_json_pointer,
+                              false);
 }
 
 inline void getStorageControllerHandler(

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -24,6 +24,7 @@
 #include "query.hpp"
 #include "redfish_util.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/asset_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/pcie_util.hpp"
@@ -362,41 +363,18 @@ inline void afterGetInventory(
     }
     BMCWEB_LOG_DEBUG("Got {} properties for system", propertiesList.size());
 
-    const std::string* partNumber = nullptr;
-    const std::string* serialNumber = nullptr;
-    const std::string* manufacturer = nullptr;
-    const std::string* model = nullptr;
+    asset_utils::extractAssetInfo(asyncResp, ""_json_pointer, propertiesList,
+                                  false);
+
     const std::string* subModel = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
-        dbus_utils::UnpackErrorPrinter(), propertiesList, "PartNumber",
-        partNumber, "SerialNumber", serialNumber, "Manufacturer", manufacturer,
-        "Model", model, "SubModel", subModel);
+        dbus_utils::UnpackErrorPrinter(), propertiesList, "SubModel", subModel);
 
     if (!success)
     {
         messages::internalError(asyncResp->res);
         return;
-    }
-
-    if (partNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["PartNumber"] = *partNumber;
-    }
-
-    if (serialNumber != nullptr)
-    {
-        asyncResp->res.jsonValue["SerialNumber"] = *serialNumber;
-    }
-
-    if (manufacturer != nullptr)
-    {
-        asyncResp->res.jsonValue["Manufacturer"] = *manufacturer;
-    }
-
-    if (model != nullptr)
-    {
-        asyncResp->res.jsonValue["Model"] = *model;
     }
 
     if (subModel != nullptr)

--- a/redfish-core/lib/systems_logservices_hwisolation.hpp
+++ b/redfish-core/lib/systems_logservices_hwisolation.hpp
@@ -6,7 +6,6 @@
 #include "bmcweb_config.h"
 
 #include "app.hpp"
-#include "assembly.hpp"
 #include "async_resp.hpp"
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
@@ -17,6 +16,7 @@
 #include "query.hpp"
 #include "registries.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/assembly_utils.hpp"
 #include "utils/error_log_utils.hpp"
 #include "utils/time_utils.hpp"
 
@@ -398,7 +398,7 @@ inline void getRedfishUriByDbusObjPath(
                             uriPropPath /= entryJsonIdx - 1;
                             uriPropPath /= "Links/OriginOfCondition/@odata.id";
 
-                            assembly::fillWithAssemblyId(
+                            assembly_utils::fillWithAssemblyId(
                                 asyncResp, std::get<0>(assemblyParent),
                                 std::get<1>(assemblyParent),
                                 std::get<2>(assemblyParent), uriPropPath,
@@ -415,7 +415,7 @@ inline void getRedfishUriByDbusObjPath(
                             auto uriPropPath =
                                 "/Links/OriginOfCondition/@odata.id"_json_pointer;
 
-                            assembly::fillWithAssemblyId(
+                            assembly_utils::fillWithAssemblyId(
                                 asyncResp, std::get<0>(assemblyParent),
                                 std::get<1>(assemblyParent),
                                 std::get<2>(assemblyParent), uriPropPath,

--- a/redfish-core/src/redfish.cpp
+++ b/redfish-core/src/redfish.cpp
@@ -73,6 +73,8 @@ RedfishService::RedfishService(App& app)
 
     requestAccountServiceRoutes(app);
     requestAccountServiceMFARoutes(app);
+    requestRoutesAssembly(app);
+
     if constexpr (BMCWEB_REDFISH_AGGREGATION)
     {
         requestRoutesAggregationService(app);
@@ -119,7 +121,6 @@ RedfishService::RedfishService(App& app)
     requestRoutesDrive(app);
     requestRoutesCable(app);
     requestRoutesCableCollection(app);
-    requestRoutesAssembly(app);
 
     requestRoutesSystemLogServiceCollection(app);
     requestRoutesEventLogService(app);


### PR DESCRIPTION
This PR redos Assembly schema using upstream Assembly schema

- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/83459 // Add getAssetInfo into util function
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/83473 //Use getAssetInfo util function
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/79009 // Add getChassisAssembly utility function
- 1120: Refactor Assembly and use inventory/assembly assoc
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/39574 // Inventory properties via Assembly schema
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/84000 //  Add LocationIndicatorActive for Assembly