### PR TITLE
1120: Fix dump offload failure

### DIFF
--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -1,22 +1,19 @@
 #pragma once
 #include "http/http_request.hpp"
 #include "http/http_response.hpp"
-// NOLINTBEGIN(misc-include-cleaner)
 #include "logging.hpp"
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/buffer.hpp>
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/steady_timer.hpp>
-#include <boost/asio/write.hpp>
 #include <boost/beast/core/error.hpp>
-#include <boost/beast/core/ostream.hpp>
-#include <boost/beast/http/basic_dynamic_body.hpp>
+#include <boost/beast/http/message.hpp>
+#include <boost/beast/http/read.hpp>
 #include <boost/beast/http/status.hpp>
+#include <boost/beast/http/write.hpp>
 #include <boost/system/error_code.hpp>
-// NOLINTEND(misc-include-cleaner)
 
 #include <cstddef>
+#include <cstdio>
+#include <format>
 #include <functional>
 #include <memory>
 #include <string>
@@ -35,7 +32,6 @@ struct Connection : std::enable_shared_from_this<Connection>
     virtual void sendMessage(const boost::asio::mutable_buffer& buffer,
                              std::function<void()> handler) = 0;
     virtual void close() = 0;
-    virtual boost::asio::io_context* getIoContext() = 0;
     virtual void sendStreamHeaders(const std::string& streamDataSize,
                                    const std::string& contentType) = 0;
     virtual void sendStreamErrorStatus(boost::beast::http::status status) = 0;
@@ -70,12 +66,6 @@ class ConnectionImpl : public Connection
         errorHandler(std::move(errorHandlerIn))
     {}
 
-    boost::asio::io_context* getIoContext() override
-    {
-        return static_cast<boost::asio::io_context*>(
-            &adaptor.get_executor().context());
-    }
-
     void start()
     {
         streamres.completeRequestHandler = [this, self(shared_from_this())] {
@@ -88,8 +78,8 @@ class ConnectionImpl : public Connection
     void sendStreamErrorStatus(boost::beast::http::status status) override
     {
         streamres.result(status);
-        boost::asio::async_write(
-            adaptor, streamres.getBufferResponse().body().data(),
+        boost::beast::http::async_write(
+            adaptor, streamres.getBufferResponse(),
             [this, self(shared_from_this())](
                 const boost::system::error_code& ec2, std::size_t) {
                 if (ec2)
@@ -113,8 +103,8 @@ class ConnectionImpl : public Connection
     {
         streamres.addHeader("Content-Length", streamDataSize);
         streamres.addHeader("Content-Type", contentType);
-        boost::asio::async_write(
-            adaptor, streamres.getBufferResponse().body().data(),
+        boost::beast::http::async_write(
+            adaptor, streamres.getBufferResponse(),
             [this, self(shared_from_this())](
                 const boost::system::error_code& ec2, std::size_t) {
                 if (ec2)
@@ -150,8 +140,8 @@ class ConnectionImpl : public Connection
 
     void doWrite()
     {
-        boost::asio::async_write(
-            adaptor, streamres.getBufferResponse().body().data(),
+        boost::beast::http::async_write(
+            adaptor, streamres.getBufferResponse(),
             [this, self(shared_from_this())](boost::beast::error_code ec,
                                              std::size_t bytesWritten) {
                 streamres.bufferResponse->body().consume(bytesWritten);


### PR DESCRIPTION
This fixes the dump offload like this

```
curl -v -k -D headers1.txt -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" \
     -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/40000006/attachment \
     --output dump.out
```

bmc journal:
```
Oct 15 15:07:28 p11bmc bmcwebd[7592]: pam_ibmacf(webserver:auth): acfv2-authenticate-0
Oct 15 15:07:28 p11bmc bmcwebd[7592]: pam_succeed_if(webserver:auth): requirement "user ingroup redfish" was met by user "service"
Oct 15 15:07:29 p11bmc bmcwebd[7592]: [dump_offload.hpp:185] Failed to connect, retrying... Retry count: 0
Oct 15 15:07:29 p11bmc phosphor-dump-manager[745]: Opening File for RW, FILENAME: SYSDUMP.13E8D2X.40000006.20251015124945
Oct 15 15:07:29 p11bmc phosphor-dump-manager[745]: writeOnUnixSocket: write() failed, errno: 32
Oct 15 15:07:29 p11bmc phosphor-dump-manager[745]: Failed to offload dump, errormsg: write() on socket failed Broken pipe, DUMPFILE: /tmp/DumpOffloadSockets/system_dump_357, DUMP_ID: 1073741830
Oct 15 15:07:29 p11bmc phosphor-dump-manager[745]: Failed to write a file
Oct 15 15:07:29 p11bmc bmcwebd[7592]: [dump_offload.hpp:150] DBUS response error: Input/output error
Oct 15 15:07:29 p11bmc bmcwebd[7592]: [dump_offload.hpp:225] DBUS response error: Unable to set the dump OffloadUri Invalid argument [generic:22]
Oct 15 15:10:18 p11bmc systemd[1]: Started OpenSSH Per-Connection Daemon (9.5.249.11:35096).
```

Tested:
```
- curl -v -k -D headers1.txt -H "X-Auth-Token: $bmc_token" -H "Content-Type: application/octet-stream" \
     -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Entries/40000006/attachment \
     --output dump.out
```