### PR TITLE
OEM: Add AllowReadOnlyAccessToAllLDAPUsers property in AccountService

### DIFF
--- a/include/sessions.hpp
+++ b/include/sessions.hpp
@@ -101,6 +101,28 @@ struct UserRoleMap
         return "";
     }
 
+    bool getAllowReadOnlyFlag()
+    {
+        std::variant<bool> value;
+        try
+        {
+            auto method = crow::connections::systemBus->new_method_call(
+                "xyz.openbmc_project.LDAP.PrivilegeMapper",
+                "/xyz/openbmc_project/user/ldap",
+                "org.freedesktop.DBus.Properties", "Get");
+            method.append("xyz.openbmc_project.User.PrivilegeMapper",
+                "AllowReadOnlyAccessToAllLDAPUsers");
+            auto reply = crow::connections::systemBus->call(method);
+            reply.read(value);
+            return std::get<bool>(value);
+        }
+        catch(const sdbusplus::exception::SdBusError& e)
+        {
+            BMCWEB_LOG_ERROR << "Failed to get AllowReadOnlyAccessToAllLDAPUsers property.";
+            BMCWEB_LOG_ERROR << "ERROR=" << e.what();
+            return true;
+        }
+    }
     std::string
         extractUserRole(const InterfacesPropertiesType& interfacesProperties)
     {
@@ -398,6 +420,10 @@ class SessionStore
         const std::string_view username, bool configureSelfOnly,
         PersistenceType persistence = PersistenceType::TIMEOUT)
     {
+        constexpr const char* objPath = "/xyz/openbmc_project/user/ldap";
+        constexpr const char* interface = "xyz.openbmc_project.User.PrivilegeMapper";
+        constexpr const char* property = "AllowReadOnlyAccessToAllLDAPUsers";
+
         // TODO(ed) find a secure way to not generate session identifiers if
         // persistence is set to SINGLE_REQUEST
         static constexpr std::array<char, 62> alphanum = {
@@ -431,11 +457,14 @@ class SessionStore
         {
             uniqueId[i] = alphanum[dist(rd)];
         }
-
+        auto& userRoleMap = UserRoleMap::getInstance();
         // Get the User Privilege
-        const std::string& role =
-            UserRoleMap::getInstance().getUserRole(username);
-
+        std::string role = userRoleMap.getUserRole(username);
+        bool allowReadOnly = userRoleMap.getAllowReadOnlyFlag();
+        if (!allowReadOnly && role.empty())
+        {
+            return nullptr;
+        }
         BMCWEB_LOG_DEBUG << "user name=\"" << username << "\" role = " << role;
         auto session = std::make_shared<UserSession>(UserSession{
             uniqueId, sessionToken, std::string(username), role, csrfToken,

--- a/include/token_authorization_middleware.hpp
+++ b/include/token_authorization_middleware.hpp
@@ -142,9 +142,15 @@ class Middleware
         // needed.
         // This whole flow needs to be revisited anyway, as we can't be
         // calling directly into pam for every request
-        return persistent_data::SessionStore::getInstance().generateUserSession(
+        std::shared_ptr<crow::persistent_data::UserSession> session =
+            persistent_data::SessionStore::getInstance().generateUserSession(
             user, passwordChangeRequired,
             crow::persistent_data::PersistenceType::SINGLE_REQUEST);
+            if (!session)
+            {
+                return nullptr;
+            }
+            return session;
     }
 
     const std::shared_ptr<crow::persistent_data::UserSession>
@@ -394,7 +400,12 @@ template <typename... Middlewares> void requestRoutes(Crow<Middlewares...>& app)
                     auto session = persistent_data::SessionStore::getInstance()
                                        .generateUserSession(
                                            username, passwordChangeRequired);
-
+                    if (! session) {
+                        BMCWEB_LOG_WARNING << "[AuthMiddleware] Session creation failed because no role mapping is configured for the remote user";
+                        res.result(boost::beast::http::status::unauthorized);
+                        res.end();
+                        return;
+                    }
 #ifdef BMCWEB_ENABLE_TRAFFIC_LOGGING
                     app.template getMiddleware<crow::logging::Middleware>().log(
                         req, res, username, true);

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -21,7 +21,6 @@
 #include <openbmc_dbus_rest.hpp>
 #include <utils/json_utils.hpp>
 #include <variant>
-
 namespace redfish
 {
 
@@ -39,6 +38,7 @@ constexpr const char* ldapCreateInterface =
 constexpr const char* ldapEnableInterface = "xyz.openbmc_project.Object.Enable";
 constexpr const char* ldapPrivMapperInterface =
     "xyz.openbmc_project.User.PrivilegeMapper";
+constexpr const char* ldapMapperInterface = "xyz.openbmc_project.LDAP.PrivilegeMapper";
 constexpr const char* dbusObjManagerIntf = "org.freedesktop.DBus.ObjectManager";
 constexpr const char* propertyInterface = "org.freedesktop.DBus.Properties";
 constexpr const char* mapperBusName = "xyz.openbmc_project.ObjectMapper";
@@ -945,13 +945,15 @@ class AccountService : public Node
         std::optional<std::string> userName;
         std::optional<std::string> password;
         std::optional<nlohmann::json> remoteRoleMapData;
+        std::optional<bool> allowReadOnlyAccessToAllLDAPUsers;
 
         if (!json_util::readJson(input, asyncResp->res, "Authentication",
                                  authentication, "LDAPService", ldapService,
                                  "ServiceAddresses", serviceAddressList,
                                  "AccountProviderType", accountProviderType,
                                  "ServiceEnabled", serviceEnabled,
-                                 "RemoteRoleMapping", remoteRoleMapData))
+                                 "RemoteRoleMapping", remoteRoleMapData,
+                                 "AllowReadOnlyAccessToAllLDAPUsers",allowReadOnlyAccessToAllLDAPUsers))
         {
             return;
         }
@@ -1159,7 +1161,30 @@ class AccountService : public Node
                                     const std::string& ldapType) {
             parseLDAPConfigData(asyncResp->res.jsonValue, confData, ldapType);
         };
-
+        crow::connections::systemBus->async_method_call(
+             [asyncResp](const boost::system::error_code ec,
+             const std::variant<bool>& value)
+             {
+                 if (ec)
+                 {
+                     BMCWEB_LOG_ERROR << "DBus Get failed for AllowReadOnlyAccessToAllLDAPUsers: "<< ec.message();
+                     return;
+                 }
+                 const bool* allowReadOnly = std::get_if<bool>(&value);
+                 if (allowReadOnly != nullptr)
+                 {
+                     asyncResp->res.jsonValue["Oem"]["OpenBMC"]["@odata.type"] =
+                        "#OpenBMCAccountService.v1_0_0.AccountService";
+                     asyncResp->res.jsonValue["Oem"]["OpenBMC"]["AllowReadOnlyAccessToAllLDAPUsers"] =
+                          *allowReadOnly;
+                 }
+             },
+             ldapMapperInterface,
+             ldapRootObject,
+             propertyInterface,
+             "Get",
+             ldapPrivMapperInterface,
+             "AllowReadOnlyAccessToAllLDAPUsers");
         getLDAPConfigData("LDAP", callback);
         getLDAPConfigData("ActiveDirectory", callback);
     }
@@ -1168,20 +1193,21 @@ class AccountService : public Node
                  const std::vector<std::string>& params) override
     {
         auto asyncResp = std::make_shared<AsyncResp>(res);
-
         std::optional<uint32_t> unlockTimeout;
         std::optional<uint16_t> lockoutThreshold;
         std::optional<uint16_t> minPasswordLength;
         std::optional<uint16_t> maxPasswordLength;
         std::optional<nlohmann::json> ldapObject;
         std::optional<nlohmann::json> activeDirectoryObject;
+        std::optional<nlohmann::json> oemObject;
 
         if (!json_util::readJson(req, res, "AccountLockoutDuration",
                                  unlockTimeout, "AccountLockoutThreshold",
                                  lockoutThreshold, "MaxPasswordLength",
                                  maxPasswordLength, "MinPasswordLength",
                                  minPasswordLength, "LDAP", ldapObject,
-                                 "ActiveDirectory", activeDirectoryObject))
+                                 "ActiveDirectory", activeDirectoryObject,
+                                 "Oem", oemObject))
         {
             return;
         }
@@ -1206,7 +1232,40 @@ class AccountService : public Node
             handleLDAPPatch(*activeDirectoryObject, asyncResp, req, params,
                             "ActiveDirectory");
         }
-
+        if (oemObject)
+        {
+            std::optional<nlohmann::json> openbmcObject;
+            if (json_util::readJson(*oemObject, res, "OpenBMC", openbmcObject))
+            {
+                std::optional<bool> allowReadOnlyAccess;
+                if (openbmcObject)
+                {
+                    json_util::readJson(*openbmcObject, res,
+                        "AllowReadOnlyAccessToAllLDAPUsers", allowReadOnlyAccess);
+                    if (allowReadOnlyAccess)
+                    {
+                        crow::connections::systemBus->async_method_call(
+                            [asyncResp, allowReadOnlyAccess](const boost::system::error_code ec)
+                            {
+                                if (ec)
+                                {
+                                    BMCWEB_LOG_ERROR << "DBus Get failed for AllowReadOnlyAccessToAllLDAPUsers: "<< ec.message();
+                                    messages::internalError(asyncResp->res);
+                                    return;
+                                }
+                                messages::success(asyncResp->res);
+                            },
+                            ldapMapperInterface,
+                            ldapRootObject,
+                            propertyInterface,
+                            "Set",
+                            ldapPrivMapperInterface,
+                            "AllowReadOnlyAccessToAllLDAPUsers",
+                            std::variant<bool>(*allowReadOnlyAccess));
+                    }
+                }
+            }
+        }
         if (unlockTimeout)
         {
             crow::connections::systemBus->async_method_call(

--- a/redfish-core/lib/redfish_sessions.hpp
+++ b/redfish-core/lib/redfish_sessions.hpp
@@ -225,6 +225,15 @@ class SessionCollection : public Node
         std::shared_ptr<crow::persistent_data::UserSession> session =
             crow::persistent_data::SessionStore::getInstance()
                 .generateUserSession(username, passwordChangeRequired);
+        if (!session)
+        {
+            BMCWEB_LOG_WARNING << "Access denied for user '" << username
+                << "': user has no role and read-only access is disabled";
+            messages::resourceAtUriUnauthorized(
+                res, std::string(req.url), "Access denied: user has no role and read-only access is disabled");
+            res.end();
+            return;
+        }
         res.addHeader("X-Auth-Token", session->sessionToken);
         res.addHeader("Location", "/redfish/v1/SessionService/Sessions/" +
                                       session->uniqueId);

--- a/static/redfish/v1/$metadata/index.xml
+++ b/static/redfish/v1/$metadata/index.xml
@@ -1316,4 +1316,8 @@
     <edmx:Reference Uri="/redfish/v1/schema/OemManager_v1.xml">
         <edmx:Include Namespace="OemManager"/>
     </edmx:Reference>
+    <edmx:Reference Uri="/redfish/v1/schema/OpenBMCAccountService_v1.xml">
+        <edmx:Include Namespace="OpenBMCAccountService"/>
+        <edmx:Include Namespace="OpenBMCAccountService.v1_0_0"/>
+    </edmx:Reference>
 </edmx:Edmx>

--- a/static/redfish/v1/JsonSchemas/OpenBMCAccountService/index.json
+++ b/static/redfish/v1/JsonSchemas/OpenBMCAccountService/index.json
@@ -1,0 +1,46 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/OpenBMCAccountService.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "definitions": {
+        "AccountService": {
+            "additionalProperties": false,
+            "description": "OEM Extension for AccountService",
+            "longDescription": "OEM Extension for AccountService to provide LDAP read-only access configuration.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "AllowReadOnlyAccessToAllLDAPUsers": {
+                    "description": "Indicates whether read-only privilege is given for LDAP users.",
+                    "longDescription": "The value of this property shall be a boolean indicating whether read-only privilege is given for LDAP users when respective privilege role map is not configured for LDAP users.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OpenBMCAccountService.v1_0_0"
+}

--- a/static/redfish/v1/schema/OpenBMCAccountService_v1.xml
+++ b/static/redfish/v1/schema/OpenBMCAccountService_v1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCAccountService">
+            <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OpenBMCAccountService.v1_0_0">
+            <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+            <Annotation Term="Redfish.Release" String="1.0"/>
+            <ComplexType Name="AccountService">
+                <Annotation Term="OData.AdditionalProperties" Bool="false"/>
+                <Annotation Term="OData.Description" String="OEM Extension for AccountService"/>
+                <Annotation Term="OData.LongDescription" String="OEM Extension for AccountService to provide LDAP read-only access configuration."/>
+                <Property Name="AllowReadOnlyAccessToAllLDAPUsers" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                    <Annotation Term="OData.Description" String="Indicates whether read-only access is allowed for all LDAP users regardless of role mapping."/>
+                    <Annotation Term="OData.LongDescription" String="If set to true, all LDAP users without specific privilege mappings will be granted read-only access."/>
+                </Property>
+            </ComplexType>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
OEM: Add AllowReadOnlyAccessToAllLDAPUsers property in AccountService
This commit implement redfish Patch/GET operation on this
AllowReadOnlyAccessToAllLDAPUsers policy and Check this flag and
correspoding role map of the user, before creating a session.
Ldap user login allowed with readonly privilege if flag is true irrespective of role map configuration
Ldap user login is not allowed if if flag is true & no matching role map configuration

Tested by:
When the newly added flag "AllowReadOnlyAccessToAllLDAPUsers " is set to false :
1.Had a proper role map configured for the ldap user and GET/login were allowed .
2.When there is no role map, login was not allowed from
GUI and session creation though redfish is also not allowed
When flag is set to true:
1.Session created even when remote user dont have role map confgured
2.Login allowed from GUI with no role map confgured

Redfish Validator Passed


Change-Id: Ib04473b5e03875a5526c1fb7a5554ec7a4ad4fa6
Signed-off-by: Kokilambal <kokilavaradhan@gmail.com>