### PR TITLE
1110: Ignore timeout on Panel GET

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2157,7 +2157,8 @@ inline void getEnabledPanelFunctions(
                                const std::vector<uint8_t>& enabledFuncs) {
             if (ec)
             {
-                if (ec.value() != EBADR &&
+                if (ec != boost::system::errc::timed_out &&
+                    ec.value() != EBADR &&
                     ec.value() != boost::asio::error::host_unreachable)
                 {
                     BMCWEB_LOG_ERROR(


### PR DESCRIPTION
System wen to no connection state after HMC got http 500 error for /redfish/v1/Systems/system. It was due to the timeout to get PanelApp GET like
```
Oct 10 05:24:43.984499 ever50bmc bmcweb[1241]: [ERROR systems.hpp:2165] Get Enabled Panel Functions D-bus error: 110
Oct 10 05:24:43.984499 ever50bmc bmcweb[1241]: [CRITICAL error_messages.cpp:287] Internal Error /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/systems.hpp(2166:44) `redfish::getEnabledPanelFunctions(const std::shared_ptr<bmcweb::AsyncResp>&)::<lambda(const boost::system::error_code&, const std::vector<unsigned char>&)>`:
Oct 10 05:24:45.334523 ever50bmc bmcweb[1241]: [ERROR systems.hpp:2165] Get Enabled Panel Functions D-bus error: 110
Oct 10 05:24:45.342107 ever50bmc bmcweb[1241]: [CRITICAL error_messages.cpp:287] Internal Error /usr/src/debug/bmcweb/1.0+git/redfish-core/lib/systems.hpp(2166:44) `redfish::getEnabledPanelFunctions(const std::shared_ptr<bmcweb::AsyncResp>&)::<lambda(const boost::system::error_code&, const std::vector<unsigned char>&)>`:
```

This is to ignore timeout error for PanelApp GET.