### PR TITLE
Audit Log: Add entries for websocket upgrades

### DIFF
--- a/features/serial/obmc_console.hpp
+++ b/features/serial/obmc_console.hpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
+#include "bmcweb_config.h"
+
 #include "app.hpp"
+#include "audit_events.hpp"
 #include "dbus_utility.hpp"
 #include "io_context_singleton.hpp"
 #include "logging.hpp"
@@ -199,6 +202,10 @@ inline void connectConsoleSocket(crow::websocket::Connection& conn,
         BMCWEB_LOG_ERROR(
             "Failed to call console Connect() method DBUS error: {}",
             ec.message());
+        if constexpr (BMCWEB_AUDIT_EVENTS)
+        {
+            audit::auditConnection(&conn, true, false);
+        }
         conn.close("Failed to connect");
         return;
     }
@@ -215,6 +222,10 @@ inline void connectConsoleSocket(crow::websocket::Connection& conn,
     if (fd == -1)
     {
         BMCWEB_LOG_ERROR("Failed to dup the DBUS unixfd error");
+        if constexpr (BMCWEB_AUDIT_EVENTS)
+        {
+            audit::auditConnection(&conn, true, false);
+        }
         conn.close("Internal error");
         return;
     }
@@ -223,8 +234,16 @@ inline void connectConsoleSocket(crow::websocket::Connection& conn,
 
     if (!iter->second->connect(fd))
     {
+        if constexpr (BMCWEB_AUDIT_EVENTS)
+        {
+            audit::auditConnection(&conn, true, false);
+        }
         close(fd);
         conn.close("Internal Error");
+    }
+    if constexpr (BMCWEB_AUDIT_EVENTS)
+    {
+        audit::auditConnection(&conn, true, true);
     }
 }
 
@@ -245,6 +264,10 @@ inline void processConsoleObject(
     {
         BMCWEB_LOG_WARNING("getDbusObject() for consoles failed. DBUS error:{}",
                            ec.message());
+        if constexpr (BMCWEB_AUDIT_EVENTS)
+        {
+            audit::auditConnection(&conn, true, false);
+        }
         conn.close("getDbusObject() for consoles failed.");
         return;
     }
@@ -254,6 +277,10 @@ inline void processConsoleObject(
     {
         BMCWEB_LOG_WARNING("getDbusObject() returned unexpected size: {}",
                            objInfo.size());
+        if constexpr (BMCWEB_AUDIT_EVENTS)
+        {
+            audit::auditConnection(&conn, true, false);
+        }
         conn.close("getDbusObject() returned unexpected size");
         return;
     }

--- a/http/websocket.hpp
+++ b/http/websocket.hpp
@@ -40,6 +40,9 @@ struct Connection : std::enable_shared_from_this<Connection>
     virtual void resumeRead() = 0;
     virtual ~Connection() = default;
     virtual boost::urls::url_view url() = 0;
+    virtual std::string clientIp() = 0;
+    virtual bool needsAudit() = 0;
+    virtual void clearAudit() = 0;
 };
 } // namespace websocket
 } // namespace crow

--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -309,6 +309,21 @@ class ConnectionImpl : public Connection
         });
     }
 
+    std::string clientIp() override
+    {
+        return session->clientIp;
+    }
+
+    bool needsAudit() override
+    {
+        return wantsAudit;
+    }
+
+    void clearAudit() override
+    {
+        wantsAudit = false;
+    }
+
   private:
     void handleMessage(size_t bytesRead)
     {
@@ -365,6 +380,8 @@ class ConnectionImpl : public Connection
     std::shared_ptr<persistent_data::UserSession> session;
 
     std::shared_ptr<Connection> selfOwned;
+
+    bool wantsAudit = true;
 };
 } // namespace websocket
 } // namespace crow

--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "http_request.hpp"
+#include "websocket.hpp"
 
 #include <boost/beast/http/verb.hpp>
 
@@ -47,7 +48,14 @@ inline bool wantAudit(const crow::Request& req)
             !checkPostUser(req));
 }
 
+void writeEvent(const std::string& opPath, const std::string& detail,
+                const std::string& userName, const std::string& ipAddress,
+                bool success);
+
 void auditEvent(const crow::Request& req, const std::string& userName,
                 bool success);
+
+void auditConnection(crow::websocket::Connection* conn, bool isNewSocket,
+                     bool success);
 
 } // namespace audit

--- a/include/obmc_hypervisor.hpp
+++ b/include/obmc_hypervisor.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "bmcweb_config.h"
+
 #include "app.hpp"
+#include "audit_events.hpp"
 #include "io_context_singleton.hpp"
 #include "logging.hpp"
 #include "websocket.hpp"
@@ -116,9 +119,19 @@ inline void connectHandler(const boost::system::error_code& ec)
         BMCWEB_LOG_ERROR("Couldn't connect to host serial port: {}", ec);
         for (crow::websocket::Connection* session : sessions)
         {
+            if constexpr (BMCWEB_AUDIT_EVENTS)
+            {
+                audit::auditConnection(session, true, false);
+            }
             session->close("Error in connecting to host port");
         }
         return;
+    }
+
+    // Audit each session. If already audited no new entry will be created
+    for (crow::websocket::Connection* session : sessions)
+    {
+        audit::auditConnection(session, true, true);
     }
 
     doWrite();
@@ -143,6 +156,12 @@ inline void requestRoutes(App& app)
                     boost::asio::local::stream_protocol::socket>(
                     getIoContext());
                 hostSocket->async_connect(ep, connectHandler);
+                return;
+            }
+
+            if constexpr (BMCWEB_AUDIT_EVENTS)
+            {
+                audit::auditConnection(&conn, false, true);
             }
         })
         .onclose([](crow::websocket::Connection& conn,

--- a/include/obmc_shell.hpp
+++ b/include/obmc_shell.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "bmcweb_config.h"
+
 #include "app.hpp"
+#include "audit_events.hpp"
 #include "io_context_singleton.hpp"
 #include "logging.hpp"
 #include "websocket.hpp"
@@ -70,6 +73,10 @@ class Handler : public std::enable_shared_from_this<Handler>
             // ERROR
             if (session != nullptr)
             {
+                if constexpr (BMCWEB_AUDIT_EVENTS)
+                {
+                    audit::auditConnection(session, true, false);
+                }
                 session->close("Error creating child process for login shell.");
             }
             return;
@@ -99,6 +106,10 @@ class Handler : public std::enable_shared_from_this<Handler>
 
             // for io operation assing file discriptor
             // to boost stream_descriptor
+            if constexpr (BMCWEB_AUDIT_EVENTS)
+            {
+                audit::auditConnection(session, true, true);
+            }
             streamFileDescriptor.assign(ttyFileDescriptor);
             doWrite();
             doRead();
@@ -206,6 +217,12 @@ inline void onOpen(crow::websocket::Connection& conn)
         {
             std::get<0>(insertData)->second->connect();
         }
+        return;
+    }
+
+    if constexpr (BMCWEB_AUDIT_EVENTS)
+    {
+        audit::auditConnection(&conn, false, true);
     }
 }
 

--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -2,6 +2,7 @@
 
 #include "http_request.hpp"
 #include "logging.hpp"
+#include "websocket.hpp"
 
 #include <audit-records.h>
 #include <audit_logging.h>
@@ -173,17 +174,14 @@ bool appendItemToBuf(std::string& strBuf, size_t maxBufSize,
     return true;
 }
 
-void auditEvent(const crow::Request& req, const std::string& userName,
+void writeEvent(const std::string& opPath, const std::string& detail,
+                const std::string& userName, const std::string& ipAddress,
                 bool success)
 {
     if (!auditOpen())
     {
         return;
     }
-
-    std::string opPath =
-        std::format("op={}:{} ", std::string(req.methodString()),
-                    std::string(req.target()));
 
     size_t maxBuf = 256; // Limit message to avoid filling log with single entry
     std::string cnfgBuff = opPath.substr(0, maxBuf);
@@ -194,14 +192,6 @@ void auditEvent(const crow::Request& req, const std::string& userName,
         BMCWEB_LOG_WARNING(
             "Audit buffer too small, truncating: cnfgBufLen={} opPathLen={}",
             cnfgBuff.length(), opPath.length());
-    }
-
-    // Determine any additional info for the event
-    std::string detail;
-    if (wantDetail(req))
-    {
-        detail = req.body().substr(0, maxBuf);
-        detail += " ";
     }
 
     if (!detail.empty())
@@ -252,8 +242,6 @@ void auditEvent(const crow::Request& req, const std::string& userName,
         (maxBuf - cnfgBuff.length()), opPath.length(), detail.length(),
         userLen);
 
-    std::string ipAddress = req.ipAddress.to_string();
-
     int rc = audit_log_user_message(
         auditfd, AUDIT_USYS_CONFIG, cnfgBuff.c_str(),
         boost::asio::ip::host_name().c_str(), ipAddress.c_str(), nullptr,
@@ -277,6 +265,54 @@ void auditEvent(const crow::Request& req, const std::string& userName,
             BMCWEB_LOG_ERROR("Error writing audit message: {}", origErrno);
         }
     }
+}
+
+void auditEvent(const crow::Request& req, const std::string& userName,
+                bool success)
+{
+    std::string opPath =
+        std::format("op={}:{} ", std::string(req.methodString()),
+                    std::string(req.target()));
+
+    // Determine any additional info for the event, limit length
+    std::string detail;
+    if (wantDetail(req))
+    {
+        detail = req.body().substr(0, 256);
+        detail += " ";
+    }
+
+    std::string ipAddress = req.ipAddress.to_string();
+
+    writeEvent(opPath, detail, userName, ipAddress, success);
+}
+
+void auditConnection(crow::websocket::Connection* conn, bool isNewSocket,
+                     bool success)
+{
+    if ((conn == nullptr) || !conn->needsAudit())
+    {
+        // Connection does not need auditing
+        return;
+    }
+
+    std::string opPath = std::format("op={} ", conn->url().path());
+    std::string isNewStr;
+    if (isNewSocket)
+    {
+        isNewStr = "true";
+    }
+    else
+    {
+        isNewStr = "false";
+    }
+    std::string detail = std::format("{{\"NewSocket\":{}}} ", isNewStr);
+    std::string userName = conn->getUserName();
+    std::string ipAddress = conn->clientIp();
+
+    BMCWEB_LOG_DEBUG("Auditing connection {} isNew: {}", opPath, isNewStr);
+    writeEvent(opPath, detail, userName, ipAddress, success);
+    conn->clearAudit();
 }
 
 } // namespace audit


### PR DESCRIPTION
Record audit entries for websocket upgrades. This includes the paths /bmc-console, /console0 (host), and /console1 (hypervisor).

In order to support the websocket upgrades the existing audit utility function was split into two pieces. auditEntry() continues to be the entry point for Redfish request structures. A new utility function auditConnection() is added for the entry point for the websocket connections. A new writeEvent() function is common between the two which does the actual recording of the audit event.

Note: The audit support is only for upgrades of the websocket. The user access validation is completed before the upgrade. If the user access validation fails no audit log entry will be written.

Note: Direct ssh to the ports used by the consoles are audited through the existing OpenSSH audit entries.

Tested: Open consoles as different users and observed audit entries being recorded.

```
// Service user
type=USYS_CONFIG msg=audit(10/06/25 19:51:35.269:40) : pid=2156 uid=root auid=service ses=8 msg='op=/console0 {"NewSocket":true} acct=service exe=/tmp/bmcwebd hostname=p11bmc addr=10.0.2.1 terminal=? res=success'

type=USYS_CONFIG msg=audit(10/06/25 19:51:41.719:41) : pid=2156 uid=root auid=service ses=8 msg='op=/bmc-console {"NewSocket":true} acct=service exe=/tmp/bmcwebd hostname=p11bmc addr=10.0.2.1 terminal=? res=success'

type=USYS_CONFIG msg=audit(10/06/25 19:51:41.789:42) : pid=2156 uid=root auid=service ses=8 msg='op=/console1 {"NewSocket":true} acct=service exe=/tmp/bmcwebd hostname=p11bmc addr=10.0.2.1 terminal=? res=success'

// Service user doing another hypervisor connection
type=USYS_CONFIG msg=audit(10/06/25 19:51:47.199:44) : pid=2156 uid=root auid=service ses=8 msg='op=/console1 {"NewSocket":false} acct=service exe=/tmp/bmcwebd hostname=p11bmc addr=10.0.2.1 terminal=? res=success'

// Non-service user can only access host console.
type=USYS_CONFIG msg=audit(10/06/25 19:51:59.979:48) : pid=2156 uid=root auid=service ses=8 msg='op=/console0 {"NewSocket":true} acct=janet exe=/tmp/bmcwebd hostname=p11bmc addr=10.0.2.1 terminal=? res=success'

/* Logged entries are returned from Redfish query */
curl -k -H "X-Auth-Token: $token"   https://${BMC_IP}/redfish/v1/Systems/system/LogServices/AuditLog/Entries?\$top=10
{
...
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1759780319.979:48",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2025-10-06T19:51:59+00:00",
      "Id": "1759780319.979:48",
      "Message": "type=\"USYS_CONFIG\" op=\"/console0\" acct=\"janet\" exe=\"/tmp/bmcwebd\" hostname=\"p11bmc\" addr=\"10.0.2.1\" terminal=\"?\" res=\"success\"",
      "MessageArgs": [
        "USYS_CONFIG",
        "/console0",
        "janet",
        "/tmp/bmcwebd",
        "p11bmc",
        "10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#IBMLogEntryAttachment.v1_0_0.IBM",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    },
...
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1759780301.789:42",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2025-10-06T19:51:41+00:00",
      "Id": "1759780301.789:42",
      "Message": "type=\"USYS_CONFIG\" op=\"/console1\" acct=\"service\" exe=\"/tmp/bmcwebd\" hostname=\"p11bmc\" addr=\"10.0.2.1\" terminal=\"?\" res=\"success\"",
      "MessageArgs": [
        "USYS_CONFIG",
        "/console1",
        "service",
        "/tmp/bmcwebd",
        "p11bmc",
        "10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#IBMLogEntryAttachment.v1_0_0.IBM",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    },
    {
      "@odata.id": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/1759780301.719:41",
      "@odata.type": "#LogEntry.v1_9_0.LogEntry",
      "EntryType": "Event",
      "EventTimestamp": "2025-10-06T19:51:41+00:00",
      "Id": "1759780301.719:41",
      "Message": "type=\"USYS_CONFIG\" op=\"/bmc-console\" acct=\"service\" exe=\"/tmp/bmcwebd\" hostname=\"p11bmc\" addr=\"10.0.2.1\" terminal=\"?\" res=\"success\"",
      "MessageArgs": [
        "USYS_CONFIG",
        "/bmc-console",
        "service",
        "/tmp/bmcwebd",
        "p11bmc",
        "10.0.2.1",
        "?",
        "success"
      ],
      "MessageId": "OpenBMC.0.5.AuditLogUsysConfig",
      "Name": "Audit Log Entry",
      "Oem": {
        "IBM": {
          "@odata.type": "#IBMLogEntryAttachment.v1_0_0.IBM",
          "AdditionalDataFullAuditLogURI": "/redfish/v1/Systems/system/LogServices/AuditLog/Entries/FullAudit/attachment"
        }
      }
    },

```