### PR TITLE
1110: Add log traces when subscription is added/deleted

### DIFF
--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -141,6 +141,7 @@ class EventServiceManager
             };
 
             subscriptionsMap.emplace(id, subValue);
+            BMCWEB_LOG_ERROR("Subscription ID: {} is loaded", id);
 
             updateNoOfSubscribersCount();
 
@@ -443,6 +444,7 @@ class EventServiceManager
             auto inserted = subscriptionsMap.insert(std::pair(id, subValue));
             if (inserted.second)
             {
+                BMCWEB_LOG_ERROR("Subscription ID: {} is added", id);
                 break;
             }
             --retry;
@@ -540,6 +542,7 @@ class EventServiceManager
             BMCWEB_LOG_ERROR("Subscription {} wasn't in persistent data", id);
             return true;
         }
+        BMCWEB_LOG_ERROR("Subscription ID: {} is deleted", id);
         persistent_data::EventServiceStore::getInstance()
             .subscriptionsConfigMap.erase(persistentObj);
         updateNoOfSubscribersCount();

--- a/redfish-core/src/subscription.cpp
+++ b/redfish-core/src/subscription.cpp
@@ -98,8 +98,9 @@ void Subscription::resHandler(const std::shared_ptr<Subscription>& /*self*/,
         hbTimer.cancel();
         if (deleter)
         {
-            BMCWEB_LOG_INFO("Subscription {} is deleted after MaxRetryAttempts",
-                            userSub->id);
+            BMCWEB_LOG_ERROR(
+                "Subscription {} is deleted after MaxRetryAttempts",
+                userSub->id);
             deleter();
         }
     }


### PR DESCRIPTION
While debugging the subscription history related to the code update, it would be easier to find where/when the subscription may be removed.

- Register a new subscription

```
Oct 24 19:11:21 p11bmc bmcweb[1839]: [ERROR event_service_manager.hpp:447] Subscription ID: 3622702393 is added
```

- A subscription is deleted

```
Oct 24 19:12:13 p11bmc bmcweb[1839]: [ERROR event_service_manager.hpp:545] Subscription ID: 3437703746 is deleted
```

- Restart bmcweb & check whether the persistent subscriptions

```
Oct 24 19:12:19 p11bmc systemd[1]: Stopping Start bmcweb server...
Oct 24 19:12:19 p11bmc systemd[1]: bmcweb.service: Deactivated successfully.
Oct 24 19:12:19 p11bmc systemd[1]: Stopped Start bmcweb server.
Oct 24 19:12:21 p11bmc systemd[1]: Started Start bmcweb server.
Oct 24 19:12:21 p11bmc bmcweb[1871]: [ERROR event_service_manager.hpp:144] Subscription ID: 3622702393 is loaded
```

Note:
If the subscription is deleted due to the max retry, it may look like

```
Oct 24 18:53:19 p11bmc bmcweb[1579]: [ERROR subscription.cpp:102] Subscription 4212505157 is deleted after MaxRetryAttempts
Oct 24 18:53:19 p11bmc bmcweb[1579]: [ERROR event_service_manager.hpp:545] Subscription ID: 4212505157 is deleted
```