### PR TITLE
Move connection count requests to warning

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -90,7 +90,7 @@ class Connection :
 
         connectionCount++;
 
-        BMCWEB_LOG_DEBUG("{} Connection created, total {}", logPtr(this),
+        BMCWEB_LOG_WARNING("{} Connection created, total {}", logPtr(this),
                          connectionCount);
     }
 
@@ -100,7 +100,7 @@ class Connection :
         cancelDeadlineTimer();
 
         connectionCount--;
-        BMCWEB_LOG_DEBUG("{} Connection closed, total {}", logPtr(this),
+        BMCWEB_LOG_WARNING("{} Connection closed, total {}", logPtr(this),
                          connectionCount);
     }
 
@@ -404,10 +404,10 @@ class Connection :
             }
         }
 
-        BMCWEB_LOG_INFO("Request:  {} HTTP/{}.{} {} {} {}", logPtr(this),
-                        req->version() / 10, req->version() % 10,
-                        req->methodString(), req->target(),
-                        req->ipAddress.to_string());
+        BMCWEB_LOG_WARNING("Request:  {} HTTP/{}.{} {} {} {}", logPtr(this),
+                           req->version() / 10, req->version() % 10,
+                           req->methodString(), req->target(),
+                           req->ipAddress.to_string());
 
         if (res.completed)
         {

--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -91,7 +91,7 @@ class Connection :
         connectionCount++;
 
         BMCWEB_LOG_WARNING("{} Connection created, total {}", logPtr(this),
-                         connectionCount);
+                           connectionCount);
     }
 
     ~Connection()
@@ -101,7 +101,7 @@ class Connection :
 
         connectionCount--;
         BMCWEB_LOG_WARNING("{} Connection closed, total {}", logPtr(this),
-                         connectionCount);
+                           connectionCount);
     }
 
     Connection(const Connection&) = delete;

--- a/redfish-core/include/event_service_manager.hpp
+++ b/redfish-core/include/event_service_manager.hpp
@@ -123,6 +123,7 @@ class EventServiceManager
             };
 
             subscriptionsMap.emplace(id, subValue);
+            BMCWEB_LOG_WARNING("Subscription ID: {} is loaded", id);
 
             updateNoOfSubscribersCount();
 
@@ -326,6 +327,7 @@ class EventServiceManager
             auto inserted = subscriptionsMap.insert(std::pair(id, subValue));
             if (inserted.second)
             {
+                BMCWEB_LOG_WARNING("Subscription ID: {} is added", id);
                 break;
             }
             --retry;
@@ -431,6 +433,7 @@ class EventServiceManager
             BMCWEB_LOG_ERROR("Subscription {} wasn't in persistent data", id);
             return true;
         }
+        BMCWEB_LOG_WARNING("Subscription ID: {} is deleted", id);
         persistent_data::EventServiceStore::getInstance()
             .subscriptionsConfigMap.erase(persistentObj);
         updateNoOfSubscribersCount();

--- a/redfish-core/src/subscription.cpp
+++ b/redfish-core/src/subscription.cpp
@@ -85,8 +85,9 @@ void Subscription::resHandler(const std::shared_ptr<Subscription>& /*self*/,
         hbTimer.cancel();
         if (deleter)
         {
-            BMCWEB_LOG_INFO("Subscription {} is deleted after MaxRetryAttempts",
-                            userSub->id);
+            BMCWEB_LOG_WARNING(
+                "Subscription {} is deleted after MaxRetryAttempts",
+                userSub->id);
             deleter();
         }
     }


### PR DESCRIPTION
WIP: A possible solution to easily debug GET requests. Move to WARNING log level 

Up the tracing for requests and ip addresses and the connection count to
warning. This will help debug problems with running out of connections.
Since log levels are runtime now, can move to warning without filling
the journal with a ton of traces.

Also pull in Myung's subscription added/deleted but move it to WARNING. 