### PR TITLE
Fix dump header data corruption

### DIFF
--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -140,8 +140,8 @@ class ConnectionImpl : public Connection
 
     void doWrite()
     {
-        boost::beast::http::async_write(
-            adaptor, streamres.getBufferResponse(),
+        boost::asio::async_write(
+            adaptor, streamres.getBufferResponse().body().data(),
             [this, self(shared_from_this())](boost::beast::error_code ec,
                                              std::size_t bytesWritten) {
                 streamres.bufferResponse->body().consume(bytesWritten);


### PR DESCRIPTION
Recent fix PR 1371 writes whole structure of http response  as a body of dump data which writes http header again
into http body, so it corrupts system dump header data. 

This commit fixes system dump header data corruption by avoid writing headers again 
using streamres.getBufferResponse().body().data()


Tested by:
Verify system Dump offload with HMC and check offloaded dump name