### PR TITLE
1120: Suppress websocket aborted error log

### DIFF
--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -241,38 +241,62 @@ class ConnectionImpl : public Connection
         selfOwned.reset();
     }
 
+    void afterRead(const std::shared_ptr<Connection>& /*self*/,
+                   const boost::beast::error_code& ec, size_t bytesRead)
+    {
+        if (ec)
+        {
+            if (ec == boost::beast::error::timeout)
+            {
+                BMCWEB_LOG_WARNING("doRead timeout: {}", ec);
+            }
+            else if (ec != boost::beast::websocket::error::closed &&
+                     ec != boost::asio::error::eof &&
+                     ec != boost::asio::ssl::error::stream_truncated)
+            {
+                BMCWEB_LOG_ERROR("doRead error {}", ec);
+            }
+            if (closeHandler)
+            {
+                std::string reason{ws.reason().reason.c_str()};
+                closeHandler(*this, reason);
+            }
+            return;
+        }
+
+        handleMessage(bytesRead);
+    }
+
     void doRead()
     {
         if (readingDefered)
         {
             return;
         }
-        ws.async_read(inBuffer, [this, self(shared_from_this())](
-                                    const boost::beast::error_code& ec,
-                                    size_t bytesRead) {
-            if (ec)
-            {
-                if (ec == boost::beast::error::timeout)
-                {
-                    BMCWEB_LOG_WARNING("doRead timeout: {}", ec);
-                }
-                else if (ec != boost::beast::websocket::error::closed &&
-                         ec != boost::asio::error::eof &&
-                         ec != boost::asio::ssl::error::stream_truncated)
-                {
-                    BMCWEB_LOG_ERROR("doRead error {}", ec);
-                }
-                if (closeHandler)
-                {
-                    std::string reason{ws.reason().reason.c_str()};
-                    closeHandler(*this, reason);
-                }
-                return;
-            }
-
-            handleMessage(bytesRead);
-        });
+        ws.async_read(inBuffer, std::bind_front(&self_t::afterRead, this,
+                                                shared_from_this()));
     }
+
+    void afterWrite(const std::shared_ptr<Connection>& /*self*/,
+                    const boost::beast::error_code& ec, size_t bytesSent)
+    {
+        doingWrite = false;
+        outBuffer.consume(bytesSent);
+        if (ec == boost::beast::websocket::error::closed)
+        {
+            // Do nothing here.  doRead handler will call the
+            // closeHandler.
+            close("Write error");
+            return;
+        }
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR("Error in ws.async_write {}", ec);
+            return;
+        }
+        doWrite();
+    }
+
     void doWrite()
     {
         // If we're already doing a write, ignore the request, it will be picked
@@ -288,25 +312,9 @@ class ConnectionImpl : public Connection
             return;
         }
         doingWrite = true;
-        ws.async_write(outBuffer.data(), [this, self(shared_from_this())](
-                                             const boost::beast::error_code& ec,
-                                             size_t bytesSent) {
-            doingWrite = false;
-            outBuffer.consume(bytesSent);
-            if (ec == boost::beast::websocket::error::closed)
-            {
-                // Do nothing here.  doRead handler will call the
-                // closeHandler.
-                close("Write error");
-                return;
-            }
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("Error in ws.async_write {}", ec);
-                return;
-            }
-            doWrite();
-        });
+        ws.async_write(
+            outBuffer.data(),
+            std::bind_front(&self_t::afterWrite, this, shared_from_this()));
     }
 
     std::string clientIp() override

--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -250,16 +250,17 @@ class ConnectionImpl : public Connection
             {
                 BMCWEB_LOG_WARNING("doRead timeout: {}", ec);
             }
+            else if (ec == boost::asio::error::operation_aborted)
+            {
+                BMCWEB_LOG_WARNING("doRead operation is aborted: {}", ec);
+            }
             else if (ec != boost::beast::websocket::error::closed &&
                      ec != boost::asio::error::eof &&
                      ec != boost::asio::ssl::error::stream_truncated)
             {
                 BMCWEB_LOG_ERROR("doRead error {}", ec);
             }
-            else if (ec == boost::asio::error::operation_aborted)
-            {
-                BMCWEB_LOG_WARNING("doRead operation is aborted: {}", ec);
-            }
+
             if (closeHandler)
             {
                 std::string reason{ws.reason().reason.c_str()};

--- a/http/websocket_impl.hpp
+++ b/http/websocket_impl.hpp
@@ -256,6 +256,10 @@ class ConnectionImpl : public Connection
             {
                 BMCWEB_LOG_ERROR("doRead error {}", ec);
             }
+            else if (ec == boost::asio::error::operation_aborted)
+            {
+                BMCWEB_LOG_WARNING("doRead operation is aborted: {}", ec);
+            }
             if (closeHandler)
             {
                 std::string reason{ws.reason().reason.c_str()};
@@ -282,16 +286,22 @@ class ConnectionImpl : public Connection
     {
         doingWrite = false;
         outBuffer.consume(bytesSent);
-        if (ec == boost::beast::websocket::error::closed)
-        {
-            // Do nothing here.  doRead handler will call the
-            // closeHandler.
-            close("Write error");
-            return;
-        }
         if (ec)
         {
-            BMCWEB_LOG_ERROR("Error in ws.async_write {}", ec);
+            if (ec == boost::beast::websocket::error::closed)
+            {
+                // Do nothing here.  doRead handler will call the
+                // closeHandler.
+                close("Write error");
+            }
+            else if (ec == boost::asio::error::operation_aborted)
+            {
+                BMCWEB_LOG_WARNING("doWrite operation is aborted: {}", ec);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR("Error in ws.async_write {}", ec);
+            }
             return;
         }
         doWrite();


### PR DESCRIPTION
When websocket is aborted under some situations like GUI console is aborted earlier before websocket write is still waiting for completion, it is currently logged as ERROR. However, it may not need to be an error. This commit will change it as WARNGING.

For example,
```
Oct 31 10:40:29 balco10 bmcwebd[1230]: [websocket_impl.hpp:305] Error in ws.async_write Operation canceled [system:125 at /usr/include/boost/beast/websocket/impl/stream_impl.hpp:355:13 in function 'bool boost::beast::websocket::stream< <template-parameter-1-1>, <anonymous> >::impl_type::check_stop_now(boost::beast::error_code&)'] 
```

Tested:
-  While GUI page is loading pages (e.g. pcie topology), close web-browser multiple times.

Change-Id: I4b16c21d2784ec0b9774ab256f833bb38fc34a27