### PR TITLE
dump offload socket: Move to get_lowest_layer()

### DIFF
--- a/http/http_stream.hpp
+++ b/http/http_stream.hpp
@@ -134,7 +134,7 @@ class ConnectionImpl : public Connection
     void close() override
     {
         streamres.end();
-        adaptor.lowest_layer().close();
+        boost::beast::get_lowest_layer(adaptor).close();
         closeHandler(*this, completionStatus);
     }
 

--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -210,7 +210,8 @@ class Handler : public std::enable_shared_from_this<Handler>
             *crow::connections::systemBus, "xyz.openbmc_project.Dump.Manager",
             dumpEntryPath, "xyz.openbmc_project.Dump.Entry", "OffloadUri",
             std::variant<std::string>(value),
-            [this](const boost::system::error_code& ec) {
+            [this,
+             self(shared_from_this())](const boost::system::error_code& ec) {
                 if (ec)
                 {
                     if (ec.value() == EBADR)
@@ -235,6 +236,10 @@ class Handler : public std::enable_shared_from_this<Handler>
 
     void cleanupSocketFiles()
     {
+        if (unixSocket.is_open())
+        {
+            unixSocket.close();
+        }
         std::error_code ec;
         bool fileExists = std::filesystem::exists(unixSocketPath, ec);
         if (ec)
@@ -245,8 +250,11 @@ class Handler : public std::enable_shared_from_this<Handler>
         }
         if (fileExists)
         {
-            unixSocket.close();
-            std::remove(unixSocketPath.c_str());
+            if (std::remove(unixSocketPath.c_str()) != 0)
+            {
+                BMCWEB_LOG_WARNING("Failed to remove socket file: {}",
+                                   unixSocketPath.string());
+            }
         }
     }
 
@@ -260,7 +268,8 @@ class Handler : public std::enable_shared_from_this<Handler>
         dbus::utility::getProperty<uint64_t>(
             "xyz.openbmc_project.Dump.Manager", dumpEntryPath,
             "xyz.openbmc_project.Dump.Entry", "Size",
-            [this](const boost::system::error_code& ec, const uint64_t size) {
+            [this, self(shared_from_this())](
+                const boost::system::error_code& ec, const uint64_t size) {
                 if (ec)
                 {
                     if (ec.value() == EBADR)


### PR DESCRIPTION
Currently, in the dump_offload code, 'adaptor.lowest_layer()' API is used while closing the underlying tcp socket. This works for ssl stream, but in websocket stream, the API will not be able to get the underlying socket, leading to a stale open socket. This way, for all the dumps offloaded, the same number of sockets were left stale.

This commit fixes the issue by utilizing "get_lowest_layer()" which is a generic API that works for ssl stream as well as websocket stream irrespective of how many wrappers are there around the tcp socket.

defect: https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=748035

Tested By:
Tested dump offload and it was successful, and no stale unix sockets
left open.
