### PR TITLE
1120: Use assembly_utils::getChassisAssembly

### DIFF
--- a/redfish-core/include/utils/assembly_utils.hpp
+++ b/redfish-core/include/utils/assembly_utils.hpp
@@ -186,7 +186,7 @@ inline void fillWithAssemblyId(
             // implemented before finding the assembly id as per bmcweb Assembly
             // design.
             dbus::utility::getSubTree(
-                "/xyz/openbmc_project/inventory", 0, chassisAssemblyInterfaces,
+                "/xyz/openbmc_project/inventory", 0, assemblyInterfaces,
                 [asyncResp, assemblyUriPropPath, assemblyParentObjPath,
                  assembledObjPath, assemblyAssoc, assembledUriVal](
                     const boost::system::error_code& ec1,

--- a/redfish-core/include/utils/chassis_utils.hpp
+++ b/redfish-core/include/utils/chassis_utils.hpp
@@ -8,38 +8,22 @@
 #include "error_messages.hpp"
 #include "logging.hpp"
 
-#include <asm-generic/errno.h>
-
 #include <boost/system/error_code.hpp>
 #include <sdbusplus/message/native_types.hpp>
 
-#include <algorithm>
 #include <array>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 namespace redfish
 {
 
 static constexpr std::array<std::string_view, 1> chassisInterfaces = {
     "xyz.openbmc_project.Inventory.Item.Chassis"};
-
-static constexpr std::array<std::string_view, 9> chassisAssemblyInterfaces = {
-    "xyz.openbmc_project.Inventory.Item.Vrm",
-    "xyz.openbmc_project.Inventory.Item.Tpm",
-    "xyz.openbmc_project.Inventory.Item.Panel",
-    "xyz.openbmc_project.Inventory.Item.Battery",
-    "xyz.openbmc_project.Inventory.Item.DiskBackplane",
-    "xyz.openbmc_project.Inventory.Item.Board",
-    "xyz.openbmc_project.Inventory.Item.Connector",
-    "xyz.openbmc_project.Inventory.Item.Drive",
-    "xyz.openbmc_project.Inventory.Item.Board.Motherboard"};
 
 namespace chassis_utils
 {
@@ -89,81 +73,6 @@ void getValidChassisPath(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             callback(chassisPath);
         });
     BMCWEB_LOG_DEBUG("checkChassisId exit");
-}
-
-inline void doGetAssociatedChassisAssembly(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisPath,
-    std::function<void(const std::vector<std::string>& assemblyList)>&&
-        callback)
-{
-    BMCWEB_LOG_DEBUG("Get associated chassis assembly");
-
-    sdbusplus::message::object_path endpointPath{chassisPath};
-    endpointPath /= "assembly";
-
-    dbus::utility::getAssociatedSubTreePaths(
-        endpointPath,
-        sdbusplus::message::object_path("/xyz/openbmc_project/inventory"), 0,
-        chassisAssemblyInterfaces,
-        [asyncResp, chassisPath, callback = std::move(callback)](
-            const boost::system::error_code& ec,
-            const dbus::utility::MapperGetSubTreePathsResponse& subtreePaths) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR(
-                        "DBUS response error for getAssociatedSubTreePaths {}",
-                        ec.value());
-                    messages::internalError(asyncResp->res);
-                    return;
-                }
-                // Pass the empty assemblyList to caller
-                callback(std::vector<std::string>());
-                return;
-            }
-
-            std::vector<std::string> sortedAssemblyList = subtreePaths;
-            std::ranges::sort(sortedAssemblyList);
-
-            callback(sortedAssemblyList);
-        });
-}
-
-/**
- * @brief Get chassis path with given chassis ID
- * @param[in] asyncResp - Shared pointer for asynchronous calls.
- * @param[in] chassisID - Chassis to which the assemblies are
- * associated.
- * @param[in] callback
- *
- * @return None.
- */
-inline void getChassisAssembly(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& chassisID,
-    std::function<void(const std::optional<std::string>& validChassisPath,
-                       const std::vector<std::string>& sortedAssemblyList)>&&
-        callback)
-{
-    BMCWEB_LOG_DEBUG("Get ChassisAssembly");
-
-    // get the chassis path
-    redfish::chassis_utils::getValidChassisPath(
-        asyncResp, chassisID,
-        [asyncResp, callback = std::move(callback)](
-            const std::optional<std::string>& validChassisPath) {
-            if (!validChassisPath)
-            {
-                // tell the caller as not valid chassisPath
-                callback(validChassisPath, std::vector<std::string>());
-                return;
-            }
-            doGetAssociatedChassisAssembly(
-                asyncResp, *validChassisPath,
-                std::bind_front(callback, validChassisPath));
-        });
 }
 
 } // namespace chassis_utils

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -14,6 +14,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/assembly_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
@@ -33,7 +34,6 @@
 #include <cmath>
 #include <functional>
 #include <memory>
-#include <optional>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -306,14 +306,15 @@ inline void getCableDownstreamResources(
     const std::string& cableObjectPath)
 {
     // retrieve Downstream Resources
-    chassis_utils::getChassisAssembly(
-        asyncResp, "chassis",
-        [asyncResp,
-         cableObjectPath](const std::optional<std::string>& validChassisPath,
+    const std::string chassisID = "chassis";
+    assembly_utils::getChassisAssembly(
+        asyncResp, chassisID,
+        [asyncResp, chassisID,
+         cableObjectPath](const boost::system::error_code& ec,
                           const std::vector<std::string>& updatedAssemblyList) {
-            if (!validChassisPath || updatedAssemblyList.empty())
+            if (ec || updatedAssemblyList.empty())
             {
-                BMCWEB_LOG_DEBUG("Chassis not found");
+                BMCWEB_LOG_DEBUG("Chassis {} not found", chassisID);
                 return;
             }
             doGetCableDownstreamResources(asyncResp, cableObjectPath,

--- a/redfish-core/lib/pcie_slots.hpp
+++ b/redfish-core/lib/pcie_slots.hpp
@@ -15,6 +15,7 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utils/assembly_utils.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
@@ -105,12 +106,12 @@ inline void addLinkedFabricAdapter(
 inline void doLinkAssociatedDiskBackplaneToChassis(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& chassisId, const std::string& drivePath, size_t index,
-    const std::optional<std::string>& validChassisPath,
+    const boost::system::error_code& ec,
     const std::vector<std::string>& assemblyList)
 {
-    if (!validChassisPath || assemblyList.empty())
+    if (ec || assemblyList.empty())
     {
-        BMCWEB_LOG_WARNING("Chassis not found");
+        BMCWEB_LOG_WARNING("Chassis {} not found", chassisId);
         messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
         return;
     }
@@ -165,7 +166,7 @@ inline void afterLinkAssociatedDiskBackplane(
     // or the only one we will have instead of looping through.
     const std::string& drivePath = endpoints[0];
     std::string chassisId{"chassis"};
-    redfish::chassis_utils::getChassisAssembly(
+    assembly_utils::getChassisAssembly(
         asyncResp, chassisId,
         std::bind_front(doLinkAssociatedDiskBackplaneToChassis, asyncResp,
                         chassisId, drivePath, index));


### PR DESCRIPTION
After the commit [1][2], assembly_utils::getChassisAssembly is added as a replacement of the older chassis_utils::getChassisAssembly. This commit is to use the new util function for the places that still use the old utils function.

Tested:
- Unit test passes
- Check the redfish outputs for Cables or PCIeSlots
- Redfish Service Validator passes

[1] https://github.com/ibm-openbmc/bmcweb/commit/711a3f2ca83be5addfde76cfec97c055db6a83fe
[2] https://gerrit.openbmc.org/c/openbmc/bmcweb/+/79009