### PR TITLE
bmcweb: Remove size limit for dump offloads

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -617,8 +617,10 @@ inline bool checkSizeLimit(int fd, crow::Response& res)
     {
         BMCWEB_LOG_ERROR("File size {} exceeds maximum allowed size of {}",
                          size, maxFileSize);
-        messages::internalError(res);
-        return false;
+        // let the offload continue even if size limit is crossed
+        // let the dealine timer take care of cancelling the offload.
+        //  messages::internalError(res);
+        //  return false;
     }
     off_t rc = lseek(fd, 0, SEEK_SET);
     if (rc < 0)


### PR DESCRIPTION
Currently, a hardcoded size limit of 20MB exists for BMC and resource dumps during offloading. This presents a limitation as dump sizes are increasing with new feature additions.

This change removes the size check in `checkSizeLimit` to allow larger dumps to be offloaded. The existing deadline timer for the offload operation is sufficient to handle cases where the dump generation takes too long, making the size check redundant.

This allows the BMC to offload as much of the dump as possible within the configured time limit.