### PR TITLE
1120: Fix CpuCore Health value

### DIFF
--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -1002,13 +1002,12 @@ inline void getProcessorPaths(
 
 inline void getSubProcessorsCoreHealth(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& objPath, bool available)
+    const std::string& service, const std::string& objPath)
 {
     dbus::utility::getProperty<bool>(
         service, objPath,
         "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp,
-         available](const boost::system::error_code& ec, bool functional) {
+        [asyncResp](const boost::system::error_code& ec, bool functional) {
             if (ec)
             {
                 if (ec.value() != EBADR)
@@ -1019,7 +1018,7 @@ inline void getSubProcessorsCoreHealth(
                 return;
             }
 
-            if (!functional || !available)
+            if (!functional)
             {
                 asyncResp->res.jsonValue["Status"]["Health"] =
                     resource::Health::Critical;
@@ -1027,59 +1026,63 @@ inline void getSubProcessorsCoreHealth(
         });
 }
 
-inline void getSubProcessorsCoreState(
+inline void afterGetSubProcessorsCorePresent(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& objPath, bool available)
+    const boost::system::error_code& ec, bool present)
 {
-    dbus::utility::getProperty<bool>(
-        service, objPath, "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp,
-         available](const boost::system::error_code& ec, bool present) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error, ec: {}", ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for Available {}",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
 
-            if (!present)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::Absent;
-            }
-            else if (!available)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::UnavailableOffline;
-            }
-        });
+    if (!present)
+    {
+        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Absent;
+        return;
+    }
 }
 
-inline void getSubProcessorsCoreStateAndHealth(
+inline void afterGetSubProcessorsCoreAvailable(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& objPath)
+    const std::string& service, const std::string& corePath,
+    const boost::system::error_code& ec, bool available)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error, ec: {}", ec.value());
+            messages::internalError(asyncResp->res);
+        }
+        return;
+    }
+
+    if (!available)
+    {
+        asyncResp->res.jsonValue["Status"]["State"] =
+            resource::State::UnavailableOffline;
+    }
+
+    dbus::utility::getProperty<bool>(
+        service, corePath, "xyz.openbmc_project.Inventory.Item", "Present",
+        std::bind_front(afterGetSubProcessorsCorePresent, asyncResp));
+}
+
+inline void getSubProcessorsCoreState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& corePath)
 {
     dbus::utility::getProperty<bool>(
-        service, objPath, "xyz.openbmc_project.State.Decorator.Availability",
+        service, corePath, "xyz.openbmc_project.State.Decorator.Availability",
         "Available",
-        [asyncResp, service,
-         objPath](const boost::system::error_code& ec, bool available) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Available {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-            getSubProcessorsCoreHealth(asyncResp, service, objPath, available);
-            getSubProcessorsCoreState(asyncResp, service, objPath, available);
-        });
+        std::bind_front(afterGetSubProcessorsCoreAvailable, asyncResp, service,
+                        corePath));
 }
 
 inline void getEnabledStatus(
@@ -1124,8 +1127,6 @@ inline void getSubProcessorsCoreData(
 
     for (const auto& [service, interfaces] : object)
     {
-        bool foundAvailability = false;
-
         for (const auto& intf : interfaces)
         {
             if (intf == "xyz.openbmc_project.Inventory.Item")
@@ -1137,16 +1138,10 @@ inline void getSubProcessorsCoreData(
             {
                 getEnabledStatus(asyncResp, service, corePath, intf);
             }
-            else if (intf == "xyz.openbmc_project.State.Decorator.Availability")
-            {
-                foundAvailability = true;
-            }
         }
 
-        if (foundAvailability)
-        {
-            getSubProcessorsCoreStateAndHealth(asyncResp, service, corePath);
-        }
+        getSubProcessorsCoreState(asyncResp, service, corePath);
+        getSubProcessorsCoreHealth(asyncResp, service, corePath);
 
         if constexpr (BMCWEB_HW_ISOLATION)
         {


### PR DESCRIPTION
Commit 788a0bd4[1] improperly follow CpuCore's state/health like in power supply's state [2].
   - Health=Critical if Available = false or Functional = false.

- However, in the previous releases [3], Health state is based on only Functional state.
  - Health=Critical if Functional = false.

So, this commit is to fix CpuCore's state/health as in the previous release [3].

Tested:

- Under Functional=true but Available=false, GET core.

```
busctl get-property xyz.openbmc_project.PLDM  /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/core10 xyz.openbmc_project.State.DecoratorAvailability   Available
b false

busctl get-property xyz.openbmc_project.PLDM  /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0/core10 xyz.openbmc_project.State.Decorator.OperationalStatus  Functional
b true
```

- GET /redfish/v1/Systems/system/Processors/<cpu>/SubProcessors/<core>

Before Fix:
```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core10
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core10",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Enabled": false,
  "Id": "core10",
  "Name": "core10",
  "Status": {
    "Health": "Critical",
    "State": "UnavailableOffline"
  }
}
```

After Fix:
```
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/dcm0-cpu0/SubProcessors/core10",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Enabled": false,
  "Id": "core10",
  "Name": "core10",
  "Status": {
    "Health": "OK",
    "State": "UnavailableOffline"
  }
}
```

[1] https://github.com/ibm-openbmc/bmcweb/commit/788a0bd4
[2] https://github.com/ibm-openbmc/bmcweb/commit/71f0ad1ec1a4db9832ef0ed8f7b629359a488b8a
[3] https://github.com/ibm-openbmc/bmcweb/pull/991