### PR TITLE
1120: Rebase Additional Upstream Commits

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -172,10 +172,32 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
     {
         state = ConnState::resolveInProgress;
         BMCWEB_LOG_DEBUG("Trying to resolve: {}, id: {}", host, connId);
+        boost::urls::host_type hostType = host.host_type();
+        if (hostType == boost::urls::host_type::name)
+        {
+            resolver.async_resolve(
+                host.encoded_host_address(), host.port(),
+                std::bind_front(&ConnectionInfo::afterResolve, this,
+                                shared_from_this()));
 
-        resolver.async_resolve(host.encoded_host_address(), host.port(),
-                               std::bind_front(&ConnectionInfo::afterResolve,
-                                               this, shared_from_this()));
+            return;
+        }
+        // If we already have an ip address, no need to resolve
+        Resolver::results_type ip;
+        boost::system::error_code ec;
+        boost::asio::ip::address addr =
+            boost::asio::ip::make_address(host.host_address(), ec);
+
+        if (ec)
+        {
+            BMCWEB_LOG_ERROR(
+                "Failed to parse already-parsed ip address.  This should not happen {}",
+                host.host_address());
+            return;
+        }
+        boost::asio::ip::tcp::endpoint end(addr, host.port_number());
+        ip.push_back(std::move(end));
+        afterResolve(shared_from_this(), boost::system::error_code(), ip);
     }
 
     void afterResolve(const std::shared_ptr<ConnectionInfo>& /*self*/,

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -841,7 +841,7 @@ inline void addPCIeFunctionList(
             std::to_string(functionNum));
         pcieFunctionList.emplace_back(std::move(pcieFunction));
     }
-    res.jsonValue["PCIeFunctions@odata.count"] = pcieFunctionList.size();
+    res.jsonValue["Members@odata.count"] = pcieFunctionList.size();
 }
 
 inline void handlePCIeFunctionCollectionGet(

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -75,6 +75,12 @@ inline void doPowerSupplyCollection(
 {
     if (ec)
     {
+        if (ec.value() == boost::system::errc::io_error)
+        {
+            BMCWEB_LOG_WARNING("Chassis not found");
+            messages::resourceNotFound(asyncResp->res, "Chassis", chassisId);
+            return;
+        }
         if (ec.value() != EBADR)
         {
             BMCWEB_LOG_ERROR("DBUS response error{}", ec.value());
@@ -114,6 +120,7 @@ inline void handlePowerSupplyCollectionHead(
          chassisId](const std::optional<std::string>& validChassisPath) {
             if (!validChassisPath)
             {
+                BMCWEB_LOG_WARNING("Chassis not found");
                 messages::resourceNotFound(asyncResp->res, "Chassis",
                                            chassisId);
                 return;
@@ -168,11 +175,19 @@ inline void afterGetValidPowerSupplyPath(
 {
     if (ec)
     {
+        if (ec.value() == boost::system::errc::io_error)
+        {
+            // Not found
+            callback(std::string(), std::string());
+            return;
+        }
         if (ec.value() != EBADR)
         {
             BMCWEB_LOG_ERROR("DBUS response error{}", ec.value());
             messages::internalError(asyncResp->res);
+            return;
         }
+        callback(std::string(), std::string());
         return;
     }
     for (const auto& [objectPath, service] : subtree)
@@ -468,6 +483,14 @@ inline void doPowerSupplyGet(
     const std::string& chassisId, const std::string& powerSupplyId,
     const std::string& powerSupplyPath, const std::string& service)
 {
+    if (powerSupplyPath.empty() || service.empty())
+    {
+        BMCWEB_LOG_WARNING("PowerSupply not found");
+        messages::resourceNotFound(asyncResp->res, "PowerSupply",
+                                   powerSupplyId);
+        return;
+    }
+
     asyncResp->res.addHeader(
         boost::beast::http::field::link,
         "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");
@@ -505,7 +528,15 @@ inline void handlePowerSupplyHead(
     // Get the correct Path and Service that match the input parameters
     getValidPowerSupplyPath(
         asyncResp, chassisId, powerSupplyId,
-        [asyncResp](const std::string&, const std::string&) {
+        [asyncResp, powerSupplyId](const std::string& powerSupplyPath,
+                                   const std::string& service) {
+            if (powerSupplyPath.empty() || service.empty())
+            {
+                BMCWEB_LOG_WARNING("PowerSupply not found");
+                messages::resourceNotFound(asyncResp->res, "PowerSupply",
+                                           powerSupplyId);
+                return;
+            }
             asyncResp->res.addHeader(
                 boost::beast::http::field::link,
                 "</redfish/v1/JsonSchemas/PowerSupply/PowerSupply.json>; rel=describedby");

--- a/src/webserver_cli.cpp
+++ b/src/webserver_cli.cpp
@@ -79,13 +79,15 @@ int main(int argc, char** argv) noexcept(false)
 
     // Attempt to async_call to set logging level
     conn->async_method_call(
-        [&io, &loglevel](boost::system::error_code& ec) mutable {
+        [&io, loglevel](boost::system::error_code& ec) mutable {
             if (ec)
             {
                 BMCWEB_LOG_ERROR("SetLogLevel returned error with {}", ec);
-                return;
             }
-            BMCWEB_LOG_INFO("logging level changed to: {}", loglevel);
+            else
+            {
+                BMCWEB_LOG_INFO("logging level changed to: {}", loglevel);
+            }
             io.stop();
         },
         service, path, iface, method, loglevel);


### PR DESCRIPTION
This PR cherry-picks the following upstream commits.

- https://github.com/openbmc/bmcweb/commit/b69e6977   // Change PCIeFunctions count to Members@odata.coun
- https://github.com/openbmc/bmcweb/commit/fa4d4c69   // Bypass resolver
- https://github.com/openbmc/bmcweb/commit/cf64ce61   // Fix lifetime issue and shutdown issue
- https://github.com/openbmc/bmcweb/commit/193582b6   // Handle NotFound error for GetSubTreeById
