### PR TITLE
Mfa defect fixes

### DIFF
--- a/redfish-core/lib/account_service_mfa_actions.hpp
+++ b/redfish-core/lib/account_service_mfa_actions.hpp
@@ -27,6 +27,42 @@
 namespace redfish
 {
 
+inline void checkAndCreateSecretKey(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& username, const std::string& userPath,
+    const boost::system::error_code& ec, bool isSecretKeySet)
+{
+    if (ec)
+    {
+        BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+        messages::internalError(asyncResp->res);
+        return;
+    }
+
+    if (isSecretKeySet)
+    {
+        BMCWEB_LOG_WARNING("Secret key is already setup for the user");
+        messages::actionNotSupported(asyncResp->res, "GenerateSecretKey");
+        return;
+    }
+
+    // If secret key is not set, then proceed to create it
+    dbus::utility::async_method_call(
+        [asyncResp, username](const boost::system::error_code& ec1,
+                              const std::string& secretKey) {
+            if (ec1)
+            {
+                BMCWEB_LOG_ERROR("D-Bus response error: {}", ec1.value());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            asyncResp->res.jsonValue["SecretKey"] = secretKey;
+        },
+        "xyz.openbmc_project.User.Manager", userPath,
+        "xyz.openbmc_project.User.TOTPAuthenticator", "CreateSecretKey");
+}
+
 inline void createSecretKeyUtil(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& username, const std::string& userPath)
@@ -36,37 +72,8 @@ inline void createSecretKeyUtil(
         "xyz.openbmc_project.User.TOTPAuthenticator", "SecretKeyIsValid",
         [asyncResp, username, userPath](const boost::system::error_code& ec,
                                         const bool isSecretKeySet) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
-                messages::internalError(asyncResp->res);
-                return;
-            }
-
-            if (isSecretKeySet)
-            {
-                BMCWEB_LOG_WARNING("Secret key is already setup for the user");
-                messages::actionNotSupported(asyncResp->res,
-                                             "GenerateSecretKey");
-                return;
-            }
-
-            // If secret key is not set, then proceed to create it
-            dbus::utility::async_method_call(
-                [asyncResp, username](const boost::system::error_code& ec1,
-                                      const std::string& secretKey) {
-                    if (ec1)
-                    {
-                        BMCWEB_LOG_ERROR("D-Bus response error: {}",
-                                         ec1.value());
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-                    asyncResp->res.jsonValue["SecretKey"] = secretKey;
-                },
-                "xyz.openbmc_project.User.Manager", userPath,
-                "xyz.openbmc_project.User.TOTPAuthenticator",
-                "CreateSecretKey");
+            checkAndCreateSecretKey(asyncResp, username, userPath, ec,
+                                    isSecretKeySet);
         });
 }
 

--- a/redfish-core/lib/account_service_mfa_actions.hpp
+++ b/redfish-core/lib/account_service_mfa_actions.hpp
@@ -31,19 +31,42 @@ inline void createSecretKeyUtil(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& username, const std::string& userPath)
 {
-    dbus::utility::async_method_call(
-        [asyncResp, username](const boost::system::error_code& ec,
-                              const std::string& secretKey) {
+    dbus::utility::getProperty<bool>(
+        "xyz.openbmc_project.User.Manager", userPath,
+        "xyz.openbmc_project.User.TOTPAuthenticator",
+        "SecretKeyIsValid",
+        [asyncResp, username, userPath](const boost::system::error_code& ec,
+                                        const bool isSecretKeySet) {
             if (ec)
             {
                 BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
                 messages::internalError(asyncResp->res);
                 return;
             }
-            asyncResp->res.jsonValue["SecretKey"] = secretKey;
-        },
-        "xyz.openbmc_project.User.Manager", userPath,
-        "xyz.openbmc_project.User.TOTPAuthenticator", "CreateSecretKey");
+
+            if (isSecretKeySet)
+            {
+                BMCWEB_LOG_WARNING("Secret key is already setup for the user");
+                messages::actionNotSupported(asyncResp->res,
+                                             "GenerateSecretKey");
+                return;
+            }
+
+            // If secret key is not set, then proceed to create it
+            dbus::utility::async_method_call(
+                [asyncResp, username](const boost::system::error_code& ec,
+                                      const std::string& secretKey) {
+                    if (ec)
+                    {
+                        BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+                        messages::internalError(asyncResp->res);
+                        return;
+                    }
+                    asyncResp->res.jsonValue["SecretKey"] = secretKey;
+                },
+                "xyz.openbmc_project.User.Manager", userPath,
+                "xyz.openbmc_project.User.TOTPAuthenticator", "CreateSecretKey");
+            });
 }
 
 inline void handleGenerateSecretKey(

--- a/redfish-core/lib/account_service_mfa_actions.hpp
+++ b/redfish-core/lib/account_service_mfa_actions.hpp
@@ -33,8 +33,7 @@ inline void createSecretKeyUtil(
 {
     dbus::utility::getProperty<bool>(
         "xyz.openbmc_project.User.Manager", userPath,
-        "xyz.openbmc_project.User.TOTPAuthenticator",
-        "SecretKeyIsValid",
+        "xyz.openbmc_project.User.TOTPAuthenticator", "SecretKeyIsValid",
         [asyncResp, username, userPath](const boost::system::error_code& ec,
                                         const bool isSecretKeySet) {
             if (ec)
@@ -54,19 +53,21 @@ inline void createSecretKeyUtil(
 
             // If secret key is not set, then proceed to create it
             dbus::utility::async_method_call(
-                [asyncResp, username](const boost::system::error_code& ec,
+                [asyncResp, username](const boost::system::error_code& ec1,
                                       const std::string& secretKey) {
-                    if (ec)
+                    if (ec1)
                     {
-                        BMCWEB_LOG_ERROR("D-Bus response error: {}", ec.value());
+                        BMCWEB_LOG_ERROR("D-Bus response error: {}",
+                                         ec1.value());
                         messages::internalError(asyncResp->res);
                         return;
                     }
                     asyncResp->res.jsonValue["SecretKey"] = secretKey;
                 },
                 "xyz.openbmc_project.User.Manager", userPath,
-                "xyz.openbmc_project.User.TOTPAuthenticator", "CreateSecretKey");
-            });
+                "xyz.openbmc_project.User.TOTPAuthenticator",
+                "CreateSecretKey");
+        });
 }
 
 inline void handleGenerateSecretKey(
@@ -346,7 +347,7 @@ inline void requestAccountServiceMFARoutes(App& app)
         // TODO this privilege should be using the generated endpoints, but
         // because of the special handling of ConfigureSelf, it's not able to
         // yet
-        .privileges({{"ConfigureUsers"}, {"ConfigureSelf"}})
+        .privileges({{"ConfigureUsers"}})
         .methods(boost::beast::http::verb::post)(
             std::bind_front(handleManagerAccountClearSecretKey, std::ref(app)));
 }


### PR DESCRIPTION
This PR contains the below changes:
1. Restrict secret key generation after MFA setup
2. Disallow RO users from clearing own secretkey

Upstream: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/74667

It fixes the following defects:
[756703](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=756703)

[756701](https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=756701)