### PR TITLE
MFA Bypass: Disallow user to patch with None

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1361,7 +1361,6 @@ inline void processAccountUpdate(
 
     if (mfaBypass)
     {
-        std::string mfaBypassDbusVal;
         // Check if the input vector contains just one bypass type:
         // as there are just two defined in the backend:
         // GoogleAuthenticator  and None
@@ -1382,14 +1381,9 @@ inline void processAccountUpdate(
                                              "MFABypass/BypassTypes", values);
             return;
         }
-        std::string mfaBypassDbusPrefix =
-            "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.";
-        if (mfaBypass->empty() || mfaBypass->front() == "None")
-        {
-            mfaBypassDbusVal =
-                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.None";
-        }
-        else
+        std::string mfaBypassDbusVal =
+            "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.None";
+        if (!mfaBypass->empty())
         {
             std::string mfaBypassVal = mfaBypass->front();
             if (mfaBypassVal == "GoogleAuthenticator")


### PR DESCRIPTION
Currently, to disable MFA bypass for a user, patching the property with "None" is allowed. But, "None" is not defined in redfish as one of the property values. This commit disallows patching MFABypass with "None".

Fixes:
https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=756907

Tested By:

* Patched with "None" and observed "PropertyValueNotInList" error ''' PATCH -d '{"MFABypass":{"BypassTypes":["None"]}}' https://${bmc}/redfish/v1/AccountService/Accounts/admin '''

* Patched with [] and it was successful ''' PATCH -d '{"MFABypass":{"BypassTypes":[]}}' https://${bmc}/redfish/v1/AccountService/Accounts/admin '''