### PR TITLE
Add service root OEM for MFA flag

### DIFF
--- a/redfish-core/lib/service_root.hpp
+++ b/redfish-core/lib/service_root.hpp
@@ -102,6 +102,33 @@ inline void handleACFWindowActive(
         std::bind_front(afterHandleACFWindowActive, asyncResp));
 }
 
+inline void handleMFAEnabled(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, "xyz.openbmc_project.User.Manager",
+        "/xyz/openbmc_project/user",
+        "xyz.openbmc_project.User.MultiFactorAuthConfiguration", "Enabled",
+        [asyncResp](const boost::system::error_code& ec,
+                    const std::string& multiFactorAuthEnabledVal) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error while fetching MultiFactorAuth property. Error: {}",
+                    ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            constexpr std::string_view mfaGoogleAuthDbusVal =
+                "xyz.openbmc_project.User.MultiFactorAuthConfiguration.Type.GoogleAuthenticator";
+            bool googleAuthEnabled =
+                (multiFactorAuthEnabledVal == mfaGoogleAuthDbusVal);
+            asyncResp->res.jsonValue["Oem"]["IBM"]["MultiFactorAuthEnabled"] =
+                googleAuthEnabled;
+        });
+}
+
 inline void fillServiceRootOemProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const boost::system::error_code& ec,
@@ -205,6 +232,7 @@ inline void handleServiceRootOem(
         "#IBMServiceRoot.v1_0_0.IBM";
 
     handleACFWindowActive(asyncResp);
+    handleMFAEnabled(asyncResp);
 }
 
 inline void handleServiceRootHead(

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -58,6 +58,11 @@
           <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
         </Property>
+        <Property Name="MultiFactorAuthEnabled" Type="IBMServiceRoot.IBM">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="An indication of whether multi factor authentication is enabled."/>
+          <Annotation Term="OData.LongDescription" String="This property shall indicate if the multi factor authentication is enabled in the system."/>
+        </Property>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMServiceRoot.v1_0_0.json
@@ -75,6 +75,12 @@
                     "longDescription": "This property shall indicate if the time window for an unauthorized agent to upload an ACF is active.",
                     "readonly": true,
                     "type": ["boolean", "null"]
+                },
+                "MultiFactorAuthEnabled": {
+                    "description": "An indication of whether multi factor authentication is enabled.",
+                    "longDescription": "This property shall indicate if the multi factor authentication is enabled in the system.",
+                    "readonly": true,
+                    "type": ["boolean", "null"]
                 }
             },
             "type": "object"


### PR DESCRIPTION
Rebasing 1110 PR : https://github.com/ibm-openbmc/bmcweb/pull/1092/files

This PR contains the changes to get the d-bus value of Multi factor enabled and populate it under service root in redfish response

Tested by:

GET https://${bmc}/redfish/v1

"Name": "Root Service",
  "Oem": {
    "@odata.type": "#OemServiceRoot.Oem",
    "IBM": {
      "@odata.type": "#OemServiceRoot.IBM",
      "ACFWindowActive": false,
      "DateTime": "2026-01-13T10:21:27+00:00",
      "DateTimeLocalOffset": "+00:00",
      "Model": "9105-42A",
      "MultiFactorAuthEnabled": true,
      "SerialNumber": "13BE960"
    }
  },

Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=758119
Upstream : OEM property, downstream only.