### PR TITLE
RBMC: Adjust Redundancy minimum properties

### DIFF
--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <format>
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <ranges>
@@ -76,11 +77,14 @@ inline void getRedundantData(
     const bool* failoversAllowed = nullptr;
     const bool* redundancyEnabled = nullptr;
     const size_t* redundancyMinimum = nullptr;
+    const size_t* redundancyMaximum = nullptr;
+    const size_t* functionalMinimum = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), propertiesList, "FailoversAllowed",
         failoversAllowed, "RedundancyEnabled", redundancyEnabled,
-        "RedundancyMinimum", redundancyMinimum);
+        "RedundancyMinimum", redundancyMinimum, "RedundancyMaximum",
+        redundancyMaximum, "FunctionalMinimum", functionalMinimum);
 
     if (!success)
     {
@@ -129,7 +133,18 @@ inline void getRedundantData(
 
     if (redundancyMinimum != nullptr)
     {
-        redundantObject["MinNumNeeded"] = *redundancyMinimum;
+        redundantObject["MinNumNeededForFaultTolerance"] = *redundancyMinimum;
+    }
+
+    if (redundancyMaximum != nullptr &&
+        *redundancyMaximum != std::numeric_limits<size_t>::max())
+    {
+        redundantObject["MaxNumSupported"] = *redundancyMaximum;
+    }
+
+    if (functionalMinimum != nullptr)
+    {
+        redundantObject["MinNumNeeded"] = *functionalMinimum;
     }
 
     redundancy->emplace_back(std::move(redundantObject));


### PR DESCRIPTION
Adjust minimum properties for the Manager Redundancy. Redfish Release 2025.4 added a second minimum property and clarified the meaning of the existing minimum property.[1][2]

The D-Bus interface
xyz.openbmc_project.State.BMC.Redundancy was updated to add the new minimum property.[3]

This commit adjusts the response to map the D-Bus values to the correct Redfish property. Additionally it adds the MaxNumSupported to the response if the D-Bus value is not the default value.

MaxNumSupported : RedundancyMaximum from D-Bus
MinNumNeededForFaultTolerance : RedundancyMinimum from D-Bus
MinNumNeeded : FunctionalMinimum from D-Bus

Tested:
  - Redfish Validator passes
  - Confirmation of results on active and passive BMC:

```
// Active BMC
 curl -k -H "X-Auth-Token: $token" -X GET https://$bmc/redfish/v1/Managers/bmc
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_15_0.Manager",
  ...
  "Redundancy": [
    {
      "@odata.id": "/redfish/v1/Managers/bmc#/Redundancy/0",
      "MemberId": "0",
      "MinNumNeeded": 1,
      "MinNumNeededForFaultTolerance": 2,
      "Mode": "Failover",
      "Name": "Manager Redundancy",
      "RedundancySet": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc"
        }
      ],
      "RedundancySet@odata.count": 1,
      "Status": {
        "Health": "OK",
        "State": "Enabled"
      }
    }
  ],
  "Redundancy@odata.count": 1,
  ...
}

// Passive BMC
curl -k -H "X-Auth-Token: $token" -X GET https://$bmc/redfish/v1/Managers/bmc
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_15_0.Manager",
  ...
  "Redundancy": [
    {
      "@odata.id": "/redfish/v1/Managers/bmc#/Redundancy/0",
      "MemberId": "0",
      "MinNumNeeded": 1,
      "MinNumNeededForFaultTolerance": 2,
      "Mode": "Failover",
      "Name": "Manager Redundancy",
      "RedundancySet": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc"
        }
      ],
      "RedundancySet@odata.count": 1,
      "Status": {
        "Health": "OK",
        "State": "Enabled"
      }
    }
  ],
  "Redundancy@odata.count": 1,
  ...
}
```

[1] https://www.dmtf.org/sites/default/files/Redfish_Release_2025.4_Overview.pdf
[2] https://redfish.dmtf.org/schemas/v1/Redundancy.v1_7_0.json
[3] https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/203