### PR TITLE
Dynamic SSL/TLS context switching to support aggregation between peer bmc

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1050,7 +1050,11 @@ inline void handleIPv6DefaultGateway(
                 return;
             }
             deleteIPv6Gateway(ifaceId, staticGatewayEntry->id, asyncResp);
-            return;
+            /*Fix: When request body contains null, 
+	     * skip and continue to next parameter*/
+            staticGatewayEntry++;
+            entryIdx++;
+            continue;
         }
         if (obj->empty())
         {


### PR DESCRIPTION
    The implementation maintains two separate SSL contexts:
    HTTPS context — standard TLS with optional client certificate.
    mTLS context — mutual TLS requiring mandatory client certificate authentication.
    The server selects the appropriate context based on the
    client’s Server Name Indication (SNI).
    This enables secure peer‑to‑peer Redfish aggregation
    while continuing to support standard HTTPS clients.

    Tested By:
        '''

            Configured peer BMC aggregation using JSON configuration files.
            Verified requests from client BMCs with TLS strict mode both enabled and disabled.
            Tested with client certificates and authentication tokens.
            HTTPS and mTLS connections are correctly established and switched based on SNI.

            curl -k -H "X-Auth-Token: $bmc_token24" -X GET https://<bmc>/redfish/v1/Systems
            tlsStrict false

            curl -k -H "X-Auth-Token: $bmc_token26"   -X \
                    POST https://<bmc26>/redfish/v1/bmc/Truststore/Certificates \
                      -H "Content-Type: application/json"  \
                     -d '{"CertificateType": "PEM", "CertificateString": "'"$CERT_STRING"'"}'

            curl -k -H "X-Auth-Token: $bmc_token26"   -X \
                    POST https://<bmc26>/redfish/v1/bmc/CertificateService.ReplaceCertificate \
                      -H "Content-Type: application/json"   -d '{
                        "CertificateType": "PEM",
                        "CertificateString": "'"$CERT_STRING"'",
                        "CertificateUri": {
                         "@odata.id": "/redfish/v1/HTTPS/Certificates/1"
                            }
                    }'

            curl -v --cert client.pem --cacert ../serverCA/ca.crt https://<bmc>/redfish/v1/Systems
            tlsStrict false

            curl -k -H "X-Auth-Token: $bmc_token24" -X GET https://<bmc>/redfish/v1/Systems
            tlsStrict true

            curl -v --cert client.pem --cacert ../serverCA/ca.crt https://<bmc>/redfish/v1/Systems
            tlsStrict true
            '''
        '''

Change-Id: I49c8f3d69d4b91a3a1ebe9b5f001943d5f1f47f8