### PR TITLE
Modifying IPV6 Static Default Gateway,  deletes the existing IPV6 Static Default Gateway

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1050,7 +1050,11 @@ inline void handleIPv6DefaultGateway(
                 return;
             }
             deleteIPv6Gateway(ifaceId, staticGatewayEntry->id, asyncResp);
-            return;
+            /*Fix: When request body contains null, 
+	     * skip and continue to next parameter*/
+            staticGatewayEntry++;
+            entryIdx++;
+            continue;
         }
         if (obj->empty())
         {


### PR DESCRIPTION
This patch updates the loop to skip null entries in IPv6StaticDefaultGateways and continue to the next parameter, ensuring that remaining gateways in the array are processed and existing gateways are preserved. Request body sent by GUI for edit is null as below: {"IPv6StaticDefaultGateways": [null,{"Address":"2001::db8"}]} 

Tested by
Get/Patch on
    '''
	PATCH   -H "Content-Type: application/json"   -d
	'{"IPv6StaticDefaultGateways":
	[{"Address":"2001::db8"}]}'
	   <bmc>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0

	GET <bmc>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0
	"IPv6StaticAddresses": [],
  	"IPv6StaticDefaultGateways": [
    	{
      		"Address": "2001::db8"
    	}
  	],
    '''