### PR TITLE
1120: Fix HMC acknowledgment support on EventLog

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2116,23 +2116,60 @@ inline void dBusEventLogEntryGet(
                         urlLogEntryPrefix, hidden));
 }
 
+inline void updateManagementSystemAckProperty(
+    const std::optional<bool>& resolved,
+    const std::optional<bool>& managementSystemAck,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& entryId)
+{
+    if (resolved.has_value())
+    {
+        setDbusProperty(asyncResp, "Resolved", "xyz.openbmc_project.Logging",
+                        "/xyz/openbmc_project/logging/entry/" + entryId,
+                        "xyz.openbmc_project.Logging.Entry", "Resolved",
+                        *resolved);
+    }
+
+    if (managementSystemAck.has_value())
+    {
+        BMCWEB_LOG_DEBUG("Updated ManagementSystemAck Property");
+        setDbusProperty(asyncResp, "ManagementSystemAck",
+                        "xyz.openbmc_project.Logging",
+                        "/xyz/openbmc_project/logging/entry/" + entryId,
+                        "org.open_power.Logging.PEL.Entry",
+                        "ManagementSystemAck", *managementSystemAck);
+    }
+}
+
 inline void dBusEventLogEntryPatch(
     const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& entryId)
 {
     std::optional<bool> resolved;
-
-    if (!json_util::readJsonPatch(req, asyncResp->res, "Resolved", resolved))
+    std::optional<bool> managementSystemAck;
+    if (!json_util::readJsonPatch(
+            req, asyncResp->res,                                   //
+            "Resolved", resolved,                                  //
+            "Oem/OpenBMC/ManagementSystemAck", managementSystemAck //
+            ))
     {
         return;
     }
-    BMCWEB_LOG_DEBUG("Set Resolved");
 
-    setDbusProperty(asyncResp, "Resolved", "xyz.openbmc_project.Logging",
-                    "/xyz/openbmc_project/logging/entry/" + entryId,
-                    "xyz.openbmc_project.Logging.Entry", "Resolved",
-                    resolved.value_or(false));
+    error_log_utils::getHiddenPropertyValue(
+        asyncResp, entryId,
+        [resolved, managementSystemAck, asyncResp,
+         entryId](const std::optional<bool>& hiddenPropVal) {
+            if (hiddenPropVal.value_or(true))
+            {
+                // 'hiddenPropVal' is true if it is not an EventLog record
+                messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
+                return;
+            }
+            updateManagementSystemAckProperty(resolved, managementSystemAck,
+                                              asyncResp, entryId);
+        });
 }
 
 inline void dBusEventLogEntryDelete(

--- a/redfish-core/lib/systems_logservices_celog.hpp
+++ b/redfish-core/lib/systems_logservices_celog.hpp
@@ -13,7 +13,6 @@
 #include "logging.hpp"
 #include "query.hpp"
 #include "registries/privilege_registry.hpp"
-#include "utils/dbus_utils.hpp"
 #include "utils/error_log_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/time_utils.hpp"
@@ -119,31 +118,6 @@ inline void dBusCELogEntryCollection(
         });
 }
 
-inline void updateManagementSystemAckProperty(
-    const std::optional<bool>& resolved,
-    const std::optional<bool>& managementSystemAck,
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& entryId)
-{
-    if (resolved.has_value())
-    {
-        setDbusProperty(asyncResp, "Resolved", "xyz.openbmc_project.Logging",
-                        "/xyz/openbmc_project/logging/entry/" + entryId,
-                        "xyz.openbmc_project.Logging.Entry", "Resolved",
-                        *resolved);
-    }
-
-    if (managementSystemAck.has_value())
-    {
-        BMCWEB_LOG_DEBUG("Updated ManagementSystemAck Property");
-        setDbusProperty(asyncResp, "ManagementSystemAck",
-                        "xyz.openbmc_project.Logging",
-                        "/xyz/openbmc_project/logging/entry/" + entryId,
-                        "org.open_power.Logging.PEL.Entry",
-                        "ManagementSystemAck", *managementSystemAck);
-    }
-}
-
 inline void requestRoutesDBusCELogEntryCollection(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Systems/<str>/LogServices/CELog/Entries/")
@@ -195,6 +169,7 @@ inline void dBusCELogEntryPatch(
          entryId](const std::optional<bool>& hiddenPropVal) {
             if (!hiddenPropVal.value_or(false))
             {
+                // 'hiddenPropVal' is false if it is not a CELog record
                 messages::resourceNotFound(asyncResp->res, "LogEntry", entryId);
                 return;
             }


### PR DESCRIPTION
Supported OEM property for LogEntry and updated code for get and patch redfish commands. Actual d-bus property name is ManagementSystemAck.

Tested:
- Validator passed

- GET EventLog

```
curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  ...
  "Oem": {
    ...
    "OpenBMC": {
      "@odata.type": "#OpenBMCLogEntry.v1_0_0.OpenBMC",
      "ManagementSystemAck": false
    }
  },
  "Resolved": false,
}
```

- PATCH EventLog

```
curl -k -H "Content-Type:application/json" -X PATCH -d '{"Oem":{"OpenBMC":{"ManagementSystemAck": true}}}' \
                https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/1

curl -k -X GET https://${bmc}/redfish/v1/Systems/system/LogServices/EventLog/Entries/1
{
  "@odata.id": "/redfish/v1/Systems/system/LogServices/EventLog/Entries/1",
  "@odata.type": "#LogEntry.v1_9_0.LogEntry",
  ...
  "Oem": {
    ...
    "OpenBMC": {
      "@odata.type": "#OpenBMCLogEntry.v1_0_0.OpenBMC",
      "ManagementSystemAck": true
    }
  },
  "Resolved": false,
}
```