### PR TITLE
Update GenerateSecretKeyRequired response_code

### DIFF
--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -2330,7 +2330,6 @@ nlohmann::json::object_t generateSecretKeyRequired(
 void generateSecretKeyRequired(crow::Response& res,
                                const boost::urls::url_view_base& arg1)
 {
-    res.result(boost::beast::http::status::forbidden);
     addMessageToErrorJson(res.jsonValue, generateSecretKeyRequired(arg1));
 }
 

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -232,7 +232,7 @@ def get_response_code(entry_id: str) -> str | None:
         "Created": "created",
         "EventSubscriptionLimitExceeded": "service_unavailable",
         "GeneralError": "internal_server_error",
-        "GenerateSecretKeyRequired": "forbidden",
+        "GenerateSecretKeyRequired": None,
         "InsufficientPrivilege": "forbidden",
         "InsufficientStorage": "insufficient_storage",
         "InstallFailed": "internal_server_error",


### PR DESCRIPTION
GenerateSecretKeyRequired should behave similar to PasswordChangeRequired.
Expecting 201 status code instead of 403

Change-Id: Iec6c925f04584b2cdd93aec743b04d6a8dbde4bc