### PR TITLE
Remove extra properties from Link

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1694,14 +1694,8 @@ inline void handleAccountServiceGet(
     nlohmann::json::object_t certificates;
     certificates["@odata.id"] =
         "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates";
-    certificates["@odata.type"] =
-        "#CertificateCollection.CertificateCollection";
     clientCertificate["Certificates"] = std::move(certificates);
     json["MultiFactorAuth"]["ClientCertificate"] = std::move(clientCertificate);
-
-    getClientCertificates(
-        asyncResp,
-        "/MultiFactorAuth/ClientCertificate/Certificates/Members"_json_pointer);
 
     json["Oem"]["OpenBMC"]["@odata.type"] =
         "#OpenBMCAccountService.v1_0_0.AccountService";


### PR DESCRIPTION
Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/87667

This fixes 1 problem saw downstream with the new 3.0.4..

The newly released 3.0.4[1] Redfish Service Validator has additional checks. It is flagging the AccountService.
```
MultiFactorAuth/ClientCertificate/Certificates
[Object]
Reference Object Error: The navigation property 'Certificates' contains extra properties.
FAIL
```

Today the AccountService looks like
```
Body Response of /redfish/v1/AccountService:
{
    "@odata.id": "/redfish/v1/AccountService",
    "@odata.type": "#AccountService.v1_15_0.AccountService",
...
    "MultiFactorAuth": {
        "ClientCertificate": {
            "CertificateMappingAttribute": "CommonName",
            "Certificates": {
                "@odata.id": "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates",
                "@odata.type": "#CertificateCollection.CertificateCollection",
                "Members": [],
                "Members@odata.count": 0
            },
            "Enabled": false,
            "RespondToUnauthenticatedClients": true
        }
    },
    "Name": "Account Service",
 ...
```

Reading AccountService schema[2], Certificates should just be a link.
```
                "Certificates": {
                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
                    "description": "The link to a collection of CA certificates used to validate client certificates.",
```

With this change:
```
"MultiFactorAuth": {
        "ClientCertificate": {
            "CertificateMappingAttribute": "CommonName",
            "Certificates": {
                "@odata.id": "/redfish/v1/AccountService/MultiFactorAuth/ClientCertificate/Certificates"
            },
            "Enabled": false,
            "RespondToUnauthenticatedClients": true
        }
    },
```

This matches other Collection Links like Roles.

[1]: https://github.com/DMTF/Redfish-Service-Validator/tags
[2]: https://redfish.dmtf.org/schemas/v1/AccountService.v1_18_1.json

Tested:
- Redfish Service Validator passes

Change-Id: I71f448f65241443a651e6d69203b21d2a1fd29e3