### PR TITLE
Redfish: Refactor StaticNameServers to use setDbusProperty helper

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1731,18 +1731,12 @@ inline void handleStaticNameServersPatch(
     const std::vector<std::string>& updatedStaticNameServers,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 {
-    sdbusplus::asio::setProperty(
-        *crow::connections::systemBus, "xyz.openbmc_project.Network",
-        "/xyz/openbmc_project/network/" + ifaceId,
+    setDbusProperty(
+        asyncResp, "xyz.openbmc_project.Network",
+        sdbusplus::message::object_path("/xyz/openbmc_project/network") /
+            ifaceId,
         "xyz.openbmc_project.Network.EthernetInterface", "StaticNameServers",
-        updatedStaticNameServers,
-        [asyncResp](const boost::system::error_code& ec) {
-            if (ec)
-            {
-                messages::internalError(asyncResp->res);
-                return;
-            }
-        });
+        "StaticNameServers", updatedStaticNameServers);
 }
 
 inline void handleIPv6StaticAddressesPatch(

--- a/scripts/generate_auth_certificates.py
+++ b/scripts/generate_auth_certificates.py
@@ -119,11 +119,9 @@ def main():
     username = args.username
     password = args.password
     if username == "root" and password == "0penBMC":
-        print(
-            """Note: Using default username 'root' and default password
+        print("""Note: Using default username 'root' and default password
             '0penBmc'. Use --username and --password flags to change these,
-            respectively."""
-        )
+            respectively.""")
     serial = 1000
 
     try:

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -19,10 +19,7 @@ WARNING = """/****************************************************************
  * github organization.
  ***************************************************************/"""
 
-REGISTRY_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+REGISTRY_HEADER = PRAGMA_ONCE + WARNING + """
 #include "registries.hpp"
 
 #include <array>
@@ -32,7 +29,6 @@ REGISTRY_HEADER = (
 namespace redfish::registries::{}
 {{
 """
-)
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -197,10 +193,7 @@ def create_Subordinate_Overrides(target_list):
     return target_list_create
 
 
-PRIVILEGE_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+PRIVILEGE_HEADER = PRAGMA_ONCE + WARNING + """
 #include "privileges.hpp"
 
 #include <array>
@@ -210,7 +203,6 @@ PRIVILEGE_HEADER = (
 namespace redfish::privileges
 {
 """
-)
 
 
 def make_privilege_registry():


### PR DESCRIPTION
Replace direct sdbusplus::asio::setProperty call with the setDbusProperty helper function in handleStaticNameServersPatch. This simplifies error handling and improves code consistency by using the common utility function.

Changes:
- Use setDbusProperty helper instead of raw sdbusplus call
- Remove explicit error handling callback (now handled by helper)
- Construct object_path using operator/ for better readability

Tested: Verified StaticNameServers PATCH operations work correctly