### PR TITLE
fix: Allow only deletion of manual guards

### DIFF
--- a/redfish-core/include/utils/hw_isolation.hpp
+++ b/redfish-core/include/utils/hw_isolation.hpp
@@ -187,6 +187,141 @@ inline void isolateResource(
 }
 
 /**
+ * @brief Helper function to call D-Bus Delete and handle errors
+ *
+ * @param[in] asyncResp - The redfish response to return to the caller.
+ * @param[in] resourceIsolatedHwEntry - The hardware isolation entry path.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name.
+ *
+ * @return The redfish response in given response buffer.
+ */
+inline void callDeleteAndHandleErrors(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& resourceIsolatedHwEntry,
+    const sdbusplus::message::object_path& resourceObjPath,
+    const std::string& hwIsolationDbusName)
+{
+    dbus::utility::async_method_call(
+        [asyncResp, resourceIsolatedHwEntry,
+         resourceObjPath](const boost::system::error_code& ec1,
+                          const sdbusplus::message::message& msg) {
+            if (!ec1)
+            {
+                BMCWEB_LOG_INFO("Successfully de-isolated hardware: {}",
+                                resourceIsolatedHwEntry);
+                messages::success(asyncResp->res);
+                return;
+            }
+
+            const sd_bus_error* dbusError = msg.get_error();
+
+            if (dbusError == nullptr)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBUS response error [{} : {}] when tried to de-isolate the given resource: {}",
+                    ec1.value(), ec1.message(), resourceIsolatedHwEntry);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            BMCWEB_LOG_ERROR(
+                "DBUS response error [{} : {}] when tried to de-isolate the given resource: {}, DBus ErrorName: {} ErrorMsg: {}",
+                ec1.value(), ec1.message(), resourceIsolatedHwEntry,
+                dbusError->name, dbusError->message);
+
+            if (std::string_view(
+                    "xyz.openbmc_project.Common.Error.NotAllowed") ==
+                dbusError->name)
+            {
+                retChassisPowerStateOffRequiredError(asyncResp,
+                                                     resourceObjPath);
+            }
+            else if (
+                std::string_view(
+                    "xyz.openbmc_project.Common.Error.InsufficientPermission") ==
+                dbusError->name)
+            {
+                messages::resourceCannotBeDeleted(asyncResp->res);
+            }
+            else
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBus Error is unsupported so returning as Internal Error");
+                messages::internalError(asyncResp->res);
+            }
+            return;
+        },
+        hwIsolationDbusName, resourceIsolatedHwEntry,
+        "xyz.openbmc_project.Object.Delete", "Delete");
+}
+
+/**
+ * @brief Helper function to check severity and perform de-isolation
+ *
+ * @param[in] asyncResp - The redfish response to return to the caller.
+ * @param[in] resourceIsolatedHwEntry - The hardware isolation entry path.
+ * @param[in] resourceObjPath - The redfish resource dbus object path.
+ * @param[in] hwIsolationDbusName - The HardwareIsolation dbus name.
+ *
+ * @return The redfish response in given response buffer.
+ *
+ * @note This function checks if the Severity is Manual before allowing
+ * deletion. Only Manual severity entries can be deleted by users.
+ */
+inline void checkSeverityAndDeisolate(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& resourceIsolatedHwEntry,
+    const sdbusplus::message::object_path& resourceObjPath,
+    const std::string& hwIsolationDbusName)
+{
+    // Check the Severity property to determine if deletion is allowed
+    // Only Manual severity can be deleted, all others (Critical, Warning,
+    // Spare) cannot
+    sdbusplus::asio::getProperty<std::string>(
+        *crow::connections::systemBus, hwIsolationDbusName,
+        resourceIsolatedHwEntry, "xyz.openbmc_project.HardwareIsolation.Entry",
+        "Severity",
+        [asyncResp, resourceIsolatedHwEntry, resourceObjPath,
+         hwIsolationDbusName](const boost::system::error_code& ec2,
+                              const std::string& severity) {
+            if (ec2)
+            {
+                BMCWEB_LOG_ERROR(
+                    "DBus response error [{} : {}] when tried to get Severity property for: {}",
+                    ec2.value(), ec2.message(), resourceIsolatedHwEntry);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Log the severity for debugging
+            BMCWEB_LOG_DEBUG(
+                "Hardware isolation entry Severity check for {}: {}",
+                resourceIsolatedHwEntry, severity);
+
+            // Check if Severity is Manual (exact match with D-Bus enum value)
+            // Only allow deletion if Severity is Manual
+            // Block deletion for Critical, Warning, and Spare
+            if (severity !=
+                "xyz.openbmc_project.HardwareIsolation.Entry.Type.Manual")
+            {
+                BMCWEB_LOG_WARNING(
+                    "Cannot de-isolate hardware isolation entry with Severity={}: {}",
+                    severity, resourceIsolatedHwEntry);
+                messages::resourceCannotBeDeleted(asyncResp->res);
+                return;
+            }
+
+            // Severity is Manual - proceed with de-isolation
+            BMCWEB_LOG_INFO("De-isolating manual hardware isolation entry: {}",
+                            resourceIsolatedHwEntry);
+
+            callDeleteAndHandleErrors(asyncResp, resourceIsolatedHwEntry,
+                                      resourceObjPath, hwIsolationDbusName);
+        });
+}
+
+/**
  * @brief API used to deisolate the given resource
  *
  * @param[in] asyncResp - The redfish response to return to the caller.
@@ -215,7 +350,7 @@ inline void deisolateResource(
             if (ec)
             {
                 BMCWEB_LOG_ERROR(
-                    "DBus response error [{} : {}] when tried to get the hardware isolation entry for the given resource dbus object path: ",
+                    "DBus response error [{} : {}] when tried to get the hardware isolation entry for the given resource dbus object path: {}",
                     ec.value(), ec.message(), resourceObjPath.str);
                 // The error code (53 == Invalid request descriptor) will be
                 // returned if dbus doesn't contains "isolated_hw_entry" for
@@ -236,56 +371,9 @@ inline void deisolateResource(
             std::string resourceIsolatedHwEntry;
             resourceIsolatedHwEntry = vEndpoints.back();
 
-            // De-isolate the given resource
-            dbus::utility::async_method_call(
-                [asyncResp, resourceIsolatedHwEntry,
-                 resourceObjPath](const boost::system::error_code& ec1,
-                                  const sdbusplus::message::message& msg) {
-                    if (!ec1)
-                    {
-                        messages::success(asyncResp->res);
-                        return;
-                    }
-
-                    BMCWEB_LOG_ERROR(
-                        "DBUS response error [{} : {}] when tried to isolate the given resource: {}",
-                        ec1.value(), ec1.message(), resourceIsolatedHwEntry);
-
-                    const sd_bus_error* dbusError = msg.get_error();
-
-                    if (dbusError == nullptr)
-                    {
-                        messages::internalError(asyncResp->res);
-                        return;
-                    }
-
-                    BMCWEB_LOG_ERROR("DBus ErrorName: {} ErrorMsg: {}",
-                                     dbusError->name, dbusError->message);
-
-                    if (std::string_view(
-                            "xyz.openbmc_project.Common.Error.NotAllowed") ==
-                        dbusError->name)
-                    {
-                        retChassisPowerStateOffRequiredError(asyncResp,
-                                                             resourceObjPath);
-                    }
-                    else if (
-                        std::string_view(
-                            "xyz.openbmc_project.Common.Error.InsufficientPermission") ==
-                        dbusError->name)
-                    {
-                        messages::resourceCannotBeDeleted(asyncResp->res);
-                    }
-                    else
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "DBus Error is unsupported so returning as Internal Error");
-                        messages::internalError(asyncResp->res);
-                    }
-                    return;
-                },
-                hwIsolationDbusName, resourceIsolatedHwEntry,
-                "xyz.openbmc_project.Object.Delete", "Delete");
+            // Check severity and perform de-isolation
+            checkSeverityAndDeisolate(asyncResp, resourceIsolatedHwEntry,
+                                      resourceObjPath, hwIsolationDbusName);
         });
 }
 


### PR DESCRIPTION
In the bmcweb hardware isolation handler, add a check on the Severity property of HW isolation D-Bus records before allowing deletion. Only records with a Manual severity type are permitted to be deleted via the REST API.

Previously, this check was absent, allowing sys-guarded (predictive or fatal) hardware records to be deleted through the hardware isolation endpoint, which could result in firmware-isolated hardware being inadvertently reconfigured.

Refactored the large lambda in deisolateResource to call smaller functions.

Tested: Verified that deletion of manual guard records succeeds and deletion of sys (predictive/fatal) guard records is rejected with an appropriate error response.

Test-results:
```
Feb 28 08:01:31 p11bmc bmcwebd[1467]: [systems_logservices_hwisolation.hpp:1157] DBUS response error [5 : Input/output error] when tried to delete the given object path:
Feb 28 08:01:31 p11bmc bmcwebd[1467]: [systems_logservices_hwisolation.hpp:1168] DBus ErrorName: xyz.openbmc_project.Common.Error.InsufficientPermission ErrorMsg: Insufficient permission to perform operation
```


1. Test core reconfiguration:
<img width="3414" height="1434" alt="image" src="https://github.com/user-attachments/assets/4eccc849-dff6-4d7b-9450-954a5a39e144" />

2. Test dimm reconfiguration:
<img width="2792" height="1310" alt="image" src="https://github.com/user-attachments/assets/c47e6c0e-5089-46fd-9a20-30622bb08ba8" />