### PR TITLE
Restrict Resource Dump Creation to service user

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -5,6 +5,7 @@
 
 #include "bmcweb_config.h"
 
+#include "account_service.hpp"
 #include "app.hpp"
 #include "async_resp.hpp"
 #include "dbus_singleton.hpp"
@@ -1111,6 +1112,22 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
             }
             if (resourceDumpParams.size() == 3)
             {
+                // Check if admin user is initiating resource dump with
+                // non-empty pwd
+                std::string roleId =
+                    getRoleIdFromPrivilege(req.session->userRole);
+                if (roleId == "Administrator")
+                {
+                    if (std::holds_alternative<std::string>(
+                            resourceDumpParams[2]) &&
+                        !std::get<std::string>(resourceDumpParams[2]).empty())
+                    {
+                        BMCWEB_LOG_WARNING(
+                            "Request to create resource dump failed. User has insufficient privilege.");
+                        messages::insufficientPrivilege(asyncResp->res);
+                        return;
+                    }
+                }
                 createDumpParams.emplace_back(
                     "com.ibm.Dump.Create.CreateParameters.Password",
                     resourceDumpParams[2]);
@@ -1125,6 +1142,7 @@ inline void createDump(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData"));
                 return;
             }
+
             createDumpParams.emplace_back(
                 "com.ibm.Dump.Create.CreateParameters.DumpType",
                 "com.ibm.Dump.Create.DumpType.Resource");


### PR DESCRIPTION
This change ensures that resource dump creation requests are permitted to admin and service user — specifically, a user with the "priv-oemibmserviceagent" and "priv-admin" privilege.

Admin users must be allowed to issue resource dumps without any password string, and PHYP checks their authority based on the exact macro they invoked.

Requests from any other users will be denied with an "Insufficient Privilege" error response from bmcweb.

The rationale behind this restriction is that resource dumps are intended solely for debugging issues in resources of the host, which are to be collected exclusively by service user. As such, access is limited to service und admin sers and explicitly restricted for all others.

Tested By:
[1] POST https://${bmc}/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData -d '{"DiagnosticDataType":"OEM","OEMDiagnosticDataType":"Resource_<string>_<pwd>"}'

Performed above operation for service user and admin user and verified the following cases:

1. From a session with Role=Administrator, initiate a resource dump and do not supply the service user password - Dump collected successfully
2. From a session with Role=Administrator, initiate a resource dump with a non-empty service user password  - Insufficient privilege error
3. From a session with the service user, initiate a resource dump with a non-empty service user password - Dump collected successfully
4. From a session with the service user, initiate a resource dump with no password - Dump collected successfully