### PR TITLE
Update GenerateSecretKeyRequired response_code

### DIFF
--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -2330,7 +2330,7 @@ nlohmann::json::object_t generateSecretKeyRequired(
 void generateSecretKeyRequired(crow::Response& res,
                                const boost::urls::url_view_base& arg1)
 {
-    addMessageToErrorJson(res.jsonValue, generateSecretKeyRequired(arg1));
+    addMessageToJsonRoot(res.jsonValue, generateSecretKeyRequired(arg1));
 }
 
 } // namespace messages

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -412,6 +412,7 @@ def make_error_function(
                 "Created",
                 "Success",
                 "PasswordChangeRequired",
+                "GenerateSecretKeyRequired",
             ]
 
             if entry_id in addMessageToJson:


### PR DESCRIPTION
GenerateSecretKeyRequired should behave similar to
PasswordChangeRequired.
Expecting 201 status code instead of 403.

Tested by

curl --insecure -X POST -D headers.txt https://${bmc}/redfish/v1/SessionService/Sessions -H "Content-Type: application/json" -d '{"UserName":"MFAUser", "Password":"0penBmc0"}' -I
HTTP/1.1 201 Created
Allow: GET, HEAD, POST
OData-Version: 4.0
X-Auth-Token: PwGj0UUtSefbWsczZC2C
Location: /redfish/v1/SessionService/Sessions/OZvC3sXnEU
Strict-Transport-Security: max-age=31536000; includeSubdomains
Pragma: no-cache
Cache-Control: no-store, max-age=0
X-Content-Type-Options: nosniff
Content-Type: application/json
Date: Tue, 03 Mar 2026 12:35:22 GMT
Content-Length: 1493

Upstream : NA, scripts/parse_registries.py is different in upstream from1120.
Fixes : https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=758119

Signed-off-by: cmjishnu <cmjishnu@gfwa166.aus.stglabs.ibm.com>