### PR TITLE
Fix NTP error response overwrite

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -273,7 +273,6 @@ inline void afterSetNTP(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         messages::internalError(asyncResp->res);
         return;
     }
-    asyncResp->res.result(boost::beast::http::status::no_content);
 }
 
 inline void handleNTPProtocolEnabled(


### PR DESCRIPTION
Fix NTP error response overwrite
    When a PATCH request contained both invalid and valid properties,
    the error response from the invalid property was overwritten by
    the success response from the valid property. This happened because
    afterSetNTP() unconditionally set HTTP 204 status, even when an
    error status had already been set.

    This change removes the unconditional 204 assignment so that error
    statuses are preserved. The framework continues to set 204 for
    successful requests, but validation errors now correctly return
    400 Bad Request. Thus ensuring clients receive accurate error
    reporting when NTP validation fails, even if other properties in
    the same request are valid.

    Tested by:
    1. Invalid NTP server with valid ProtocolEnabled: Returns 400
       GET: {"NTPServers": ["pool.ntp.org"]}
       PATCH: {"NTPServers":["-8.-8.-8.-8"],
               "ProtocolEnabled":true}
       GET: {"NTPServers": ["pool.ntp.org"]} (unchanged)

    2. Valid NTP server with valid ProtocolEnabled: Returns 204
       GET: {"NTPServers": ["pool.ntp.org"]}
       PATCH: {"NTPServers":["192.168.1.1"],
               "ProtocolEnabled":true}
       GET: {"NTPServers": ["192.168.1.1"]} (updated)

    3. Invalid NTP server only: Returns 400
       GET: {"NTPServers": ["8.8.8.8","pool.ntp.org",
                            "2001:4860:4860::8888"]}
       PATCH: {"NTPServers":["gggg::1"]}
       GET: {"NTPServers": ["8.8.8.8","pool.ntp.org",
                            "2001:4860:4860::8888"]} (unchanged)

    4. Valid NTP server only: Returns 204
       GET: {"NTPServers": ["8.8.8.8","pool.ntp.org",
                            "2001:4860:4860::8888"]}
       PATCH: {"NTPServers":["ntp1.example.co.uk"]}
       GET: {"NTPServers": ["ntp1.example.co.uk"]} (updated)

    5. Multiple valid NTP servers: Returns 204
       GET: {"NTPServers": ["ntp1.example.co.uk"]}
       PATCH: {"NTPServers":["129.6.15.28","1pool.ntp.org",
                             "fe80::11"],
               "ProtocolEnabled":true}
       GET: {"NTPServers": ["129.6.15.28","1pool.ntp.org",
                            "fe80::11"]} (updated)
```

Change-Id: I13f4926539f9da8da0244835db5fda8f67bdf1df