### PR TITLE
1210: Fix IPv6 static gateway PATCH entry preservation (#1398)

### DIFF
--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -1050,7 +1050,9 @@ inline void handleIPv6DefaultGateway(
                 return;
             }
             deleteIPv6Gateway(ifaceId, staticGatewayEntry->id, asyncResp);
-            return;
+            staticGatewayEntry++;
+            entryIdx++;
+            continue;
         }
         if (obj->empty())
         {


### PR DESCRIPTION
#### Fix IPv6 static gateway PATCH entry preservation (#1398)
```
Function handling IPv6DefaultGateway previously returned immediately
after deleting a gateway, which prevented processing of subsequent
entries. This change increments the gateway entry and index, thus
continues the loop instead of returning early.

This ensures that editing an existing gateway entry updates correctly.

Tested by:
Get/Patch on
```
- 1.1: Add 3 gateways
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8::1"},
    {"Address":"2001:db8::2"},{"Address":"2001:db8::3"}]}'

- 1.2: Replace with 2 gateways
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8::10"},
    {"Address":"2001:db8::20"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8::1"
  },
  {
    "Address": "2001:db8::10"
  },
  {
    "Address": "2001:db8::20"
  }

- 1.3: Add 4 gateways, then [null,null,null,{"Address":"fe80::13"}]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8::100"},
    {"Address":"2001:db8::101"},{"Address":"2001:db8::102"},
    {"Address":"2001:db8::103"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[null,null,null,
    {"Address":"fe80::13"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "fe80::13"
  }

- 2: Add gateways incrementally
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:a::1"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:a::1"},
    {"Address":"2001:db8:a::2"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:a::1"},
    {"Address":"2001:db8:a::2"},{"Address":"2001:db8:a::3"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:a::1"},
    {"Address":"2001:db8:a::2"},{"Address":"2001:db8:a::3"},
    {"Address":"2001:db8:a::4"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:a::1"
  },
  {
    "Address": "2001:db8:a::2"
  },
  {
    "Address": "2001:db8:a::3"
  },
  {
    "Address": "2001:db8:a::4"
  }

- 3.1: Add one gateway, then patch [null, gateway], and get
   PATCH -d '{"IPv6StaticDefaultGateways":[
     {"Address":"2001:db8:a::11"}]}'
   GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:a::11"
  }
  PATCH -d '{"IPv6StaticDefaultGateways":[null,
    {"Address":"2001:db8:a::21"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:a::21"
  }

- 3.2: No gateway configured, then patch [Gateway, null]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:b::10"},
    null]}'
  {
  "code": "Base.1.19.ResourceCannotBeDeleted",
    "message": "The delete request failed because the resource
      requested cannot be deleted."
  }

- 3.3: No gateway configured, patch [null,null,gateway]
  PATCH -d '{"IPv6StaticDefaultGateways":[null,null,
    {"Address":"2001:db8:b::20"}]}'
  {
  "code": "Base.1.19.ResourceCannotBeDeleted",
    "message": "The delete request failed because the resource
      requested cannot be deleted."
  }

- 3.4: Add 2 gateways, patch [Gateway, null, gateway]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:b::30"},
    {"Address":"2001:db8:b::31"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:b::30"},
    null,{"Address":"2001:db8:b::31"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:b::30"
  },
  {
    "Address": "2001:db8:b::31"
  }

- 4.1: Add 2 gateway and patch [{}]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:c::1"},
    {"Address":"2001:db8:c::2"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:c::2"
  },
  {
    "Address": "2001:db8:c::1"
  }

- 4.2: Add 2 gateway and patch [{},{gateway}]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8:c::1"},
    {"Address":"2001:db8:c::2"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[{},
    {"Address":"2001:db8:c::10"}]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "2001:db8:c::10"
  },
  {
    "Address": "2001:db8:c::2"
  }

- 5.1: Add 4 gateways and patch [null,null,null]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"fe80::10"},
    {"Address":"fe80::11"},{"Address":"fe80::12"},
    {"Address":"fe80::13"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[null,null,null]}'
  GET <bmc_ip>/redfish/v1/Managers/bmc/EthernetInterfaces/eth0 | jq
    '.IPv6StaticDefaultGateways'
  {
    "Address": "fe80::11"
  }

- 5.2: Add 2 gateways and patch [null,null,null]
  PATCH -d '{"IPv6StaticDefaultGateways":[{"Address":"2001:db8::10"},
    {"Address":"2001:db8::20"}]}'
  PATCH -d '{"IPv6StaticDefaultGateways":[null,null,null]}'
  {
  "code": "Base.1.19.ResourceCannotBeDeleted",
    "message": "The delete request failed because the resource
      requested cannot be deleted."
  }

```

Change-Id: I0c3f0bf2589551010869c7df45df26372cb24656```