### PR TITLE
Send Exit Utilization before Enter to prevent conflict

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2424,6 +2424,22 @@ inline void setIdlePowerSaver(
                     "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                     "Enabled", *ipsEnable);
             }
+            if (ipsExitUtil)
+            {
+                setDbusProperty(
+                    asyncResp, "IdlePowerSaver/ExitUtilizationPercent", service,
+                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
+                    "ExitUtilizationPercent", *ipsExitUtil);
+            }
+            if (ipsExitTime)
+            {
+                // Convert from seconds into milliseconds for DBus
+                const uint64_t timeMilliseconds = *ipsExitTime * 1000;
+                setDbusProperty(
+                    asyncResp, "IdlePowerSaver/ExitDwellTimeSeconds", service,
+                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
+                    "ExitDwellTime", timeMilliseconds);
+            }
             if (ipsEnterUtil)
             {
                 setDbusProperty(
@@ -2440,22 +2456,6 @@ inline void setIdlePowerSaver(
                     asyncResp, "IdlePowerSaver/EnterDwellTimeSeconds", service,
                     path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                     "EnterDwellTime", timeMilliseconds);
-            }
-            if (ipsExitUtil)
-            {
-                setDbusProperty(
-                    asyncResp, "IdlePowerSaver/ExitUtilizationPercent", service,
-                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
-                    "ExitUtilizationPercent", *ipsExitUtil);
-            }
-            if (ipsExitTime)
-            {
-                // Convert from seconds into milliseconds for DBus
-                const uint64_t timeMilliseconds = *ipsExitTime * 1000;
-                setDbusProperty(
-                    asyncResp, "IdlePowerSaver/ExitDwellTimeSeconds", service,
-                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
-                    "ExitDwellTime", timeMilliseconds);
             }
         });
 


### PR DESCRIPTION
The Idle Power Saver parameters have an enter and exit utilization that have dependencies on each other. The enter must be less than or equal to the exit utilization.

DBUS properties are set individually which can lead to a condition where the new enter utilization could be larger than the current exit utilization. When that condition is encountered, the enter utilization is updated to the current exit utilization.

This fix will reverse the order (exit before enter) preventing requested utilization values from being lost.

Tested on Everest hardware and validator was run.

Change-Id: Id8a68650b1c0dfb825d0df35a742ffd0fb2d8a4a