### PR TITLE
1210: fix issues with validator 3.0.6 (#1413)

### DIFF
--- a/redfish-core/include/utils/sensor_utils.hpp
+++ b/redfish-core/include/utils/sensor_utils.hpp
@@ -492,7 +492,7 @@ inline void objectPropertiesToJson(
 
         if (chassisSubNode == ChassisSubNode::sensorsNode)
         {
-            sensorJson["@odata.type"] = "#Sensor.v1_2_0.Sensor";
+            sensorJson["@odata.type"] = "#Sensor.v1_7_0.Sensor";
 
             sensor::ReadingType readingType =
                 sensors::toReadingType(sensorType);

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1672,7 +1672,7 @@ inline void handleAccountServiceGet(
     nlohmann::json::array_t allowed;
     allowed.emplace_back(account_service::BasicAuthState::Enabled);
     allowed.emplace_back(account_service::BasicAuthState::Disabled);
-    json["HTTPBasicAuth@AllowableValues"] = std::move(allowed);
+    json["HTTPBasicAuth@Redfish.AllowableValues"] = std::move(allowed);
 
     nlohmann::json::object_t clientCertificate;
     clientCertificate["Enabled"] = authMethodsConfig.tls;

--- a/redfish-core/lib/certificate_service.hpp
+++ b/redfish-core/lib/certificate_service.hpp
@@ -1226,7 +1226,7 @@ inline void handleTrustStoreCertificateCollectionGet(
     }
 
     asyncResp->res.jsonValue["@odata.id"] =
-        boost::urls::format("/redfish/v1/Managers/{}/Truststore/Certificates/",
+        boost::urls::format("/redfish/v1/Managers/{}/Truststore/Certificates",
                             BMCWEB_REDFISH_MANAGER_URI_NAME);
     asyncResp->res.jsonValue["@odata.type"] =
         "#CertificateCollection.CertificateCollection";

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -68,13 +68,11 @@ inline void getLicenseEntryCollection(
                 }
                 entriesArray.push_back({});
                 nlohmann::json& thisEntry = entriesArray.back();
-                thisEntry["@odata.id"] = std::format(
+                thisEntry["@odata.id"] = boost::urls::format(
                     "/redfish/v1/LicenseService/Licenses/{}", entryID);
-                thisEntry["Id"] = entryID;
-                thisEntry["Name"] = entryID + " License Entry";
-                asyncResp->res.jsonValue["Members@odata.count"] =
-                    entriesArray.size();
             }
+            asyncResp->res.jsonValue["Members@odata.count"] =
+                entriesArray.size();
         });
 }
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -2784,10 +2784,11 @@ inline void handleLogServicesDumpClearLogComputerSystemPost(
 
 inline void displayOemPelAttachment(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& entryID)
+    const boost::urls::url& urlLogEntryPrefix, const std::string& entryID)
 {
-    auto respHandler = [asyncResp, entryID](const boost::system::error_code& ec,
-                                            const std::string& pelJson) {
+    auto respHandler = [asyncResp, urlLogEntryPrefix,
+                        entryID](const boost::system::error_code& ec,
+                                 const std::string& pelJson) {
         if (ec.value() == EBADR)
         {
             messages::resourceNotFound(asyncResp->res, "OemPelAttachment",
@@ -2800,6 +2801,14 @@ inline void displayOemPelAttachment(
             messages::internalError(asyncResp->res);
             return;
         }
+
+        asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+            "{}/{}/OemPelAttachment", urlLogEntryPrefix, entryID);
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#IBMLogEntryAttachment.v1_0_0.IBMLogEntryAttachment";
+
+        asyncResp->res.jsonValue["Name"] = "OemPelAttachment";
+        asyncResp->res.jsonValue["Id"] = "OemPelAttachment";
 
         asyncResp->res.jsonValue["Oem"]["IBM"]["PelJson"] = pelJson;
         asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
@@ -2868,7 +2877,11 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
                                                        "LogEntry", entryID);
                             return;
                         }
-                        displayOemPelAttachment(asyncResp, entryID);
+                        boost::urls::url urlLogEntryPrefix = boost::urls::format(
+                            "/redfish/v1/Systems/{}/LogServices/EventLog/Entries",
+                            BMCWEB_REDFISH_SYSTEM_URI_NAME);
+                        displayOemPelAttachment(asyncResp, urlLogEntryPrefix,
+                                                entryID);
                     });
             });
 }

--- a/redfish-core/lib/systems_logservices_celog.hpp
+++ b/redfish-core/lib/systems_logservices_celog.hpp
@@ -335,7 +335,12 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
                                                        "LogEntry", entryID);
                             return;
                         }
-                        displayOemPelAttachment(asyncResp, entryID);
+
+                        boost::urls::url urlLogEntryPrefix = boost::urls::format(
+                            "/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                            BMCWEB_REDFISH_SYSTEM_URI_NAME);
+                        displayOemPelAttachment(asyncResp, urlLogEntryPrefix,
+                                                entryID);
                     });
             });
 }

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1245,8 +1245,8 @@ inline void handleUpdateServiceGet(
     asyncResp->res.jsonValue["MaxImageSizeBytes"] =
         BMCWEB_HTTP_BODY_LIMIT * 1024 * 1024;
     nlohmann::json& updateSvcConUpdate =
-        asyncResp->res.jsonValue["Actions"]["Oem"]
-                                ["#OemUpdateService.v1_0_0.ConcurrentUpdate"];
+        asyncResp->res
+            .jsonValue["Actions"]["Oem"]["#OemUpdateService.ConcurrentUpdate"];
     updateSvcConUpdate["target"] =
         "/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate";
 

--- a/redfish-core/schema/oem/ibm/csdl/IBMFabricAdapter_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMFabricAdapter_v1.xml
@@ -27,7 +27,7 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="IBMFabricAdapter Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMFabricAdapter.IBM"/>
+        <Property Name="IBM" Type="IBMFabricAdapter.v1_0_0.IBM"/>
       </ComplexType>
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>

--- a/redfish-core/schema/oem/ibm/csdl/IBMLogEntryAttachment_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMLogEntryAttachment_v1.xml
@@ -18,14 +18,17 @@
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMLogEntryAttachment.v1_0_0">
-      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
-      <ComplexType Name="Oem" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="IBMLogEntryAttachment Oem properties."/>
-        <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMLogEntryAttachment.v1_0_0.IBM"/>
-      </ComplexType>
+      <EntityType Name="IBMLogEntryAttachment" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <ComplexType Name="Oem" BaseType="Resource.OemObject">
+          <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+          <Annotation Term="OData.Description" String="IBMLogEntryAttachment Oem properties."/>
+          <Annotation Term="OData.AutoExpand"/>
+          <Property Name="IBM" Type="IBMLogEntryAttachment.v1_0_0.IBM"/>
+        </ComplexType>
+      </EntityType>
+
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
@@ -39,6 +42,7 @@
           <Annotation Term="OData.Description" String="Audit Log in Json format."/>
         </Property>
       </ComplexType>
+
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
@@ -26,13 +26,13 @@
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="IBM" Type="IBMManagerAccount.v1_0_0.IBM"/>
       </ComplexType>
-      <ComplexType Name="IBM">
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="ACF" Type="IBMManagerAccount.v1_0_0.ACF"/>
       </ComplexType>
-      <ComplexType Name="ACF">
+      <ComplexType Name="ACF" BaseType="Resource.OemObject">
         <Annotation Term="OData.Description" String="A collection of ACF properties."/>
         <Annotation Term="OData.LongDescription" String="A collection of access control file properties."/>
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
@@ -41,11 +41,11 @@
       </ComplexType>
 
       <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
-        <Property Name="PCIeSlot" Type="Resource.Resource">
+        <NavigationProperty Name="PCIeSlot" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PCIe Slot Link"/>
           <Annotation Term="OData.LongDescription" String="Represent PCIe Slot Link which has all PCIe device list."/>
-        </Property>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
@@ -49,15 +49,15 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="AssociatedAssembly" Type="Resource.Resource">
+        <NavigationProperty Name="AssociatedAssembly" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
-        </Property>
-        <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
+        </NavigationProperty>
+        <NavigationProperty Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The upstream fabric adapters."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the upstream fabric adapters."/>
-        </Property>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -53,12 +53,12 @@
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
-        <Property Name="ACFWindowActive" Type="IBMServiceRoot.IBM">
+        <Property Name="ACFWindowActive" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
         </Property>
-        <Property Name="MultiFactorAuthEnabled" Type="IBMServiceRoot.IBM">
+        <Property Name="MultiFactorAuthEnabled" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="An indication of whether multi factor authentication is enabled."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the multi factor authentication is enabled in the system."/>

--- a/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
@@ -13,8 +13,6 @@
   <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
-    </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService.v1_0_0">
       <Action Name="ConcurrentUpdate" IsBound="true">
         <Annotation Term="OData.Description" String="This action concurrently updates firmware."/>
         <Annotation Term="OData.LongDescription" String="This action concurrently updates firmware, synchronizing the host and bmc."/>

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
@@ -26,7 +26,7 @@
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="OpenBMC" Type="OpenBMCLogEntry.v1_0_0.OpenBMC"/>
       </ComplexType>
-      <ComplexType Name="OpenBMC">
+      <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
         <Annotation Term="OData.AutoExpand"/>

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCManager_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCManager_v1.xml
@@ -38,6 +38,12 @@
           <Annotation Term="OData.Description" String="OpenBMC fan configuration."/>
           <Annotation Term="OData.LongDescription" String="OpenBMC fan configuration."/>
         </Property>
+        <NavigationProperty Name="Certificates" Type="CertificateCollection.CertificateCollection" ContainsTarget="true" Nullable="false">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
+          <Annotation Term="OData.Description" String="The link to a collection of certificates for device identity and attestation."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain a link to a resource collection of type `CertificateCollection` that contains certificates for device identity and attestation."/>
+          <Annotation Term="OData.AutoExpandReferences"/>
+        </NavigationProperty>
       </ComplexType>
       <ComplexType Name="Fan">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
@@ -24,9 +24,9 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="OpenBMCMessage Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="OpenBMC" Type="OpenBMCMessage.OpenBMC"/>
+        <Property Name="OpenBMC" Type="OpenBMCMessage.v1_0_0.OpenBMC"/>
       </ComplexType>
-      <ComplexType Name="OpenBMC">
+      <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
         <Annotation Term="OData.AutoExpand"/>

--- a/redfish-core/schema/oem/openbmc/json-schema/OpenBMCManager.v1_0_0.json
+++ b/redfish-core/schema/oem/openbmc/json-schema/OpenBMCManager.v1_0_0.json
@@ -327,6 +327,12 @@
                     ],
                     "description": "OpenBMC fan configuration.",
                     "longDescription": "OpenBMC fan configuration."
+                },
+                "Certificates": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/CertificateCollection.json#/definitions/CertificateCollection",
+                    "description": "The link to a collection of certificates for device identity and attestation.",
+                    "longDescription": "This property shall contain a link to a resource collection of type `CertificateCollection` that contains certificates for device identity and attestation.",
+                    "readonly": true
                 }
             },
             "type": "object"

--- a/redfish-core/schema/oem/openbmc/meson.build
+++ b/redfish-core/schema/oem/openbmc/meson.build
@@ -1,31 +1,22 @@
+# Schemas to install
+schemas_to_install = ['OpenBMCAccountService', 'OpenBMCManager']
+
 # Mapping from option key name to schemas that should be installed if that option is enabled
 schemas = {
-    'insecure-disable-auth': 'OpenBMCAccountService',
-    'redfish-oem-manager-fan-data': 'OpenBMCManager',
     'redfish-provisioning-feature': 'OpenBMCComputerSystem',
     #'vm-nbdproxy': 'OpenBMCVirtualMedia',
 }
 
 foreach option_key, schema : schemas
     if get_option(option_key).allowed()
-        install_data(
-            'csdl/@0@_v1.xml'.format(schema),
-            install_dir: 'share/www/redfish/v1/schema',
-            follow_symlinks: true,
-        )
-
-        install_data(
-            'json-schema/@0@.v1_0_0.json'.format(schema),
-            install_dir: 'share/www/redfish/v1/JsonSchemas',
-            follow_symlinks: true,
-        )
+        schemas_to_install += schema
     endif
 endforeach
 
 # Additional IBM schemas that should be installed
-ibm_schemas = ['OpenBMCAssembly', 'OpenBMCLogEntry', 'OpenBMCMessage']
+schemas_to_install += ['OpenBMCAssembly', 'OpenBMCLogEntry', 'OpenBMCMessage']
 
-foreach schema : ibm_schemas
+foreach schema : schemas_to_install
     install_data(
         'csdl/@0@_v1.xml'.format(schema),
         install_dir: 'share/www/redfish/v1/schema',


### PR DESCRIPTION
This PR contains the following commits.

- Fix Redfish Service Validator 3.0.6 issues (#1413)
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/83894 - AccountService: Use @Redfish.AllowableValues annotation
- https://gerrit.openbmc.org/c/openbmc/bmcweb/+/87821  Fix Oem/OpenBMC Redfish Service Validator warnings

Fix Redfish Service Validator 3.0.6 issues (#1413)

The new Redfish Service Validator with 3.0.6 reports the new errors like
- Oem/IBM/ACFWindowActive
  Property Type Error: The property 'ACFWindowActive' is expected to be
an object, but found 'bool'.

- redfish/v1/Chassis/chassis/Sensors/pressure_Station_Pressure
  Property Value Error: The value 'PressurePa' for the property
'ReadingType' requires the resource version to be '1.7.0' or higher.

- /redfish/v1/LicenseService/Licenses
Members/0 - Reference Object Error: The navigation property 'Members'
contains extra properties.

- /redfish/v1/Systems/system/PCIeDevices/<str>
```
Links/Oem/IBM/PCIeSlot/@odata.typ
[Not Present]
Required Property Error: The property '@odata.type' is mandatory, but not present in the payload.
FAIL
```

- /redfish/v1/Chassis/chassis/PCIeSlots
```
Slots/0/Links/Oem/IBM/AssociatedAssembly/@odata.type
[Not Present]
Required Property Error: The property '@odata.type' is mandatory, but not present in the payload.
FAIL
```

- /redfish/v1/Systems/system/LogServices/<str>/Entries/<str>/OemPelAttachment
```
Unknown Resource Type
@odata.type
[Not Present]
Required Property Error: The property '@odata.type' is mandatory, but not present in the payload.
FAIL
```

- /redfish/v1/Systems/system/LogServices/EventLog/Entries/1
```
Oem/OpenBMC
[Object]
Object Type Error: The object 'OpenBMC' contains a value for '@odata.type' that is not valid for type 'Resource.OemObject'.
WARN
```

-  /redfish/v1/UpdateService
```
Actions/Oem/#OemUpdateService.v1_0_0.ConcurrentUpdate/target
/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate
Action URI Error: The target URI for the action is expected to be '/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.v1_0_0.ConcurrentUpdate'.
FAIL
```

Tested:
- Redfish Service Validator 3.0.6 run passes on those URIs