### PR TITLE
Systems: Send Exit Utilization before Enter

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2455,6 +2455,22 @@ inline void setIdlePowerSaver(
                     "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                     "Enabled", "IdlePowerSaver/Enabled", *ipsEnable);
             }
+            if (ipsExitUtil)
+            {
+                setDbusProperty(
+                    asyncResp, "IdlePowerSaver/ExitUtilizationPercent", service,
+                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
+                    "ExitUtilizationPercent", *ipsExitUtil);
+            }
+            if (ipsExitTime)
+            {
+                // Convert from seconds into milliseconds for DBus
+                const uint64_t timeMilliseconds = *ipsExitTime * 1000;
+                setDbusProperty(
+                    asyncResp, "IdlePowerSaver/ExitDwellTimeSeconds", service,
+                    path, "xyz.openbmc_project.Control.Power.IdlePowerSaver",
+                    "ExitDwellTime", timeMilliseconds);
+            }
             if (ipsEnterUtil)
             {
                 setDbusProperty(
@@ -2471,24 +2487,6 @@ inline void setIdlePowerSaver(
                     asyncResp, service, path,
                     "xyz.openbmc_project.Control.Power.IdlePowerSaver",
                     "EnterDwellTime", "IdlePowerSaver/EnterDwellTimeSeconds",
-                    timeMilliseconds);
-            }
-            if (ipsExitUtil)
-            {
-                setDbusProperty(
-                    asyncResp, service, path,
-                    "xyz.openbmc_project.Control.Power.IdlePowerSaver",
-                    "ExitUtilizationPercent",
-                    "IdlePowerSaver/ExitUtilizationPercent", *ipsExitUtil);
-            }
-            if (ipsExitTime)
-            {
-                // Convert from seconds into milliseconds for DBus
-                const uint64_t timeMilliseconds = *ipsExitTime * 1000;
-                setDbusProperty(
-                    asyncResp, service, path,
-                    "xyz.openbmc_project.Control.Power.IdlePowerSaver",
-                    "ExitDwellTime", "IdlePowerSaver/ExitDwellTimeSeconds",
                     timeMilliseconds);
             }
         });


### PR DESCRIPTION
The Idle Power Saver parameters have an enter and exit utilization that have dependencies on each other. The enter must be less than or equal to the exit utilization.

DBUS properties are set individually which can lead to a condition where the new enter utilization could be larger than the current exit utilization. When that condition is encountered, the enter utilization is updated to the current exit utilization.

This fix will reverse the order (exit before enter) preventing requested utilization values from being lost.

Original code example:
initial utils: enter = 8, exit = 12
user requests: enter = 18, exit = 22
app gets exit value first and sees that (new enter) 18 > (current exit)
    12 , so it updates both to the current exit value (12)
app then gets exit value and updates the exit to 22 BAD resulting values: enter = 12, exit = 22

With fix:
initial utils: enter = 8, exit = 12
user requests: enter = 18, exit = 22
app gets exit value first and updates it -> enter = 8 and exit = 22 app then gets enter value and updates the enter to 18 GOOD resulting values: enter = 18, exit = 22

Reverse case with fix:
initial utils: enter = 8, exit = 12
user requests: enter = 4, exit = 6
app gets exit value first and sees that (current enter) 8 > (new exit)
    6, so it updates both to the new exit value (6)
app then gets enter value and updates the enter to 4 GOOD resulting values: enter = 4, exit = 6

Tested on Everest hardware and validator was run.

Change-Id: Id8a68650b1c0dfb825d0df35a742ffd0fb2d8a4a