### PR TITLE
1120: Fix TOD battery ReadyToRemove value

### DIFF
--- a/redfish-core/lib/assembly_battery_cm.hpp
+++ b/redfish-core/lib/assembly_battery_cm.hpp
@@ -59,8 +59,10 @@ inline void getReadyToRemoveOfTodBattery(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     std::size_t assemblyIndex)
 {
+    constexpr std::array<std::string_view, 1> interfaces = {
+        "xyz.openbmc_project.State.Decorator.OperationalStatus"};
     dbus::utility::getDbusObject(
-        "/xyz/openbmc_project/sensors/voltage/Battery_Voltage", {},
+        "/xyz/openbmc_project/sensors/voltage/Battery_Voltage", interfaces,
         std::bind_front(afterGetReadyToRemoveOfTodBattery, asyncResp,
                         assemblyIndex));
 }


### PR DESCRIPTION
Even after PATCH ReadyToRemove of TOD battery to true, its ReadyToRemove value is not changed. It is because dbus GetObject of ObjectManager does not return an error even if the target service is stopped.

1. GET TOD Battery

```
curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly

      "Name": "Time-of-day battery",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OpenBMCAssembly.v1_0_0.OpenBMC",
          "ReadyToRemove": false
        }
      },
```

2. PATCH ReadyToRemove to true

```
curl  -H "Content-Type:application/json" -k -X PATCH https://${bmc}/redfish/v1/Chassis/chassis/Assembly  -d '{"Assemblies":[{"MemberId":"3","Oem":{"OpenBMC":{"ReadyToRemove":true}}}]}'
```

3. GET TOD Battery
```
      "Name": "Time-of-day battery",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OpenBMCAssembly.v1_0_0.OpenBMC",
          "ReadyToRemove": false
        }
      },
```

Tested:
- With the fix, after PATCH, ReadyToRemove will become `true`.