### PR TITLE
1060: Fix TOD battery ReadyToRemove value

### DIFF
--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -142,7 +142,8 @@ inline void
                 "/xyz/openbmc_project/object_mapper",
                 "xyz.openbmc_project.ObjectMapper", "GetObject",
                 "/xyz/openbmc_project/sensors/voltage/Battery_Voltage",
-                std::array<const char*, 0>{});
+                std::array<const char*, 1>{
+                    "xyz.openbmc_project.State.Decorator.OperationalStatus"});
         }
 
         crow::connections::systemBus->async_method_call(

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -19,10 +19,7 @@ WARNING = """/****************************************************************
  * github organization.
  ***************************************************************/"""
 
-REGISTRY_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+REGISTRY_HEADER = PRAGMA_ONCE + WARNING + """
 #include "registries.hpp"
 
 #include <array>
@@ -32,7 +29,6 @@ REGISTRY_HEADER = (
 namespace redfish::registries::{}
 {{
 """
-)
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -173,10 +169,7 @@ def create_Subordinate_Overrides(target_list):
     return target_list_create
 
 
-PRIVILEGE_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+PRIVILEGE_HEADER = PRAGMA_ONCE + WARNING + """
 #include "privileges.hpp"
 
 #include <array>
@@ -186,7 +179,6 @@ PRIVILEGE_HEADER = (
 namespace redfish::privileges
 {
 """
-)
 
 
 def make_privilege_registry():


### PR DESCRIPTION
Even after PATCH ReadyToRemove of TOD battery to true, its ReadyToRemove value is not changed. It is because dbus GetObject of ObjectManager does not return an error even if the target service is stopped.

1. GET TOD Battery

```
curl -k -X GET https://${bmc}/redfish/v1/Chassis/chassis/Assembly

      "Name": "Time-of-day battery",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OpenBMCAssembly.v1_0_0.OpenBMC",
          "ReadyToRemove": false
        }
      },
```

2. PATCH ReadyToRemove to true

```
curl  -H "Content-Type:application/json" -k -X PATCH https://${bmc}/redfish/v1/Chassis/chassis/Assembly  -d '{"Assemblies":[{"MemberId":"3","Oem":{"OpenBMC":{"ReadyToRemove":true}}}]}'
```

3. GET TOD Battery
```
      "Name": "Time-of-day battery",
      "Oem": {
        "OpenBMC": {
          "@odata.type": "#OpenBMCAssembly.v1_0_0.OpenBMC",
          "ReadyToRemove": false
        }
      },
```

Tested:
- With the fix, after PATCH, ReadyToRemove will become `true`.