### PR TITLE
Fix : PATCH always returns 204 response for invalid arguments (#1412)

### DIFF
--- a/redfish-core/lib/network_protocol.hpp
+++ b/redfish-core/lib/network_protocol.hpp
@@ -273,7 +273,6 @@ inline void afterSetNTP(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
         messages::internalError(asyncResp->res);
         return;
     }
-    asyncResp->res.result(boost::beast::http::status::no_content);
 }
 
 inline void handleNTPProtocolEnabled(


### PR DESCRIPTION
Problem:
It is observed that PATCH request network protocol using request

```
curl -k -u ${credentials} -X PATCH https://${IP}/redfish/v1/Managers/bmc/NetworkProtocol -d '{"NTP": {"ProtocolEnabled": true, "NTPServers": ["\n"]}}' -H "Content-Type:application/json"
returns 204 response.

Root cause : The 400 Bad response set by bmcweb when NTP server set
value "NTPServers": ["\n"]  is overridden by "ProtocolEnabled" response
value of 204  therefore we were getting 204 response for invalid
arguments as well.

Fix : Check the response of "NTPServers" value in async object and set
the response code

The MRs for PDI and phosphor network are as below

https://gerrit.openbmc.org/c/openbmc/phosphor-dbus-interfaces/+/82693
https://gerrit.openbmc.org/c/openbmc/phosphor-networkd/+/82694

Testing:
curl -k -u ${credentials} -X PATCH https://${IP}/redfish/v1/Managers/bmc/NetworkProtocol -d '{"NTP": {"ProtocolEnabled": true, "NTPServers": ["\n"]}}' -H "Content-Type:application/json"
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The property 'NTP/NTPServers/' with the requested value of '[\"\\n\"]' could not be written because the value does not meet the constraints of the implementation.",
        "MessageArgs": [
          "NTP/NTPServers/",
          "[\"\\n\"]"
        ],
        "MessageId": "Base.1.19.PropertyValueIncorrect",
        "MessageSeverity": "Warning",
        "Resolution": "None."
      }
    ],
    "code": "Base.1.19.PropertyValueIncorrect",
    "message": "The property 'NTP/NTPServers/' with the requested value of '[\"\\n\"]' could not be written because the value does not meet the constraints of the implementation."
  }
}
```

Change-Id: Icfbfc3d065a6a307344093eef8b2eb3e39c70f83