### PR TITLE
Fix: Redfish Service Validator 3.1.0 Conformance

### DIFF
--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2297,6 +2297,7 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
             oemIBM["@odata.type"] = "#IBMComputerSystem.v1_0_0.IBM";
 
             nlohmann::json& chapData = oemIBM["ChapData"];
+            chapData["@odata.type"] = "#IBMComputerSystem.v1_0_0.ChapData";
             chapData["ChapName"] = *chapName;
             chapData["ChapSecret"] = *chapSecret;
         });
@@ -2829,8 +2830,8 @@ inline void handleComputerSystemGet(
     getEnabledPanelFunctions(asyncResp);
 
     nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
-    actionOem["#IBMComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
-        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction";
+    actionOem["#IBMComputerSystem.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.ExecutePanelFunction";
 
     // ChapData
     getChapData(asyncResp);
@@ -3283,7 +3284,7 @@ inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
 {
     BMCWEB_ROUTE(
         app,
-        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction/")
+        "/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.ExecutePanelFunction/")
         .privileges(redfish::privileges::postComputerSystem)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -59,8 +59,21 @@
           <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is active."/>
         </Property>
       </ComplexType>
+      <Action Name="ExecutePanelFunction" IsBound="true">
+        <Annotation Term="OData.Description" String="This action executes a panel function."/>
+        <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
+        <Parameter Name="FuncNo" Type="IBMComputerSystem.v1_0_0.OemActions" Nullable="false">
+          <Annotation Term="OData.Description" String="Panel function number."/>
+          <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
+        </Parameter>
+      </Action>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMComputerSystem.v1_0_0">
+      <ComplexType Name="OemActions">
+        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+        <Annotation Term="OData.Description" String="The available OEM-specific actions for this resource."/>
+        <Annotation Term="OData.LongDescription" String="This type shall contain the available OEM-specific actions for this resource."/>
+      </ComplexType>
       <ComplexType Name="IBM" BaseType="IBMComputerSystem.IBM">
         <Property Name="EnabledPanelFunctions" Type="Collection(Edm.Int64)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
@@ -88,14 +101,6 @@
           <Annotation Term="OData.LongDescription" String="This property shall contain ChapSecret that is an encrypted secret password transferred to the Host for the respective ChapName."/>
         </Property>
       </ComplexType>
-      <Action Name="ExecutePanelFunction" IsBound="true">
-        <Annotation Term="OData.Description" String="This action executes a panel function."/>
-        <Annotation Term="OData.LongDescription" String="This action executes a panel function if the function is enabled."/>
-        <Parameter Name="FuncNo" Type="IBMComputerSystem.v1_0_0.OemActions" Nullable="false">
-          <Annotation Term="OData.Description" String="Panel function number."/>
-          <Annotation Term="OData.LongDescription" String="This parameter shall contain a  panel function number to be executed."/>
-        </Parameter>
-      </Action>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
IBMComputerSystems Schema was reporting fails on:

- Actions/Oem/#IBMComputerSystem.v1_0_0.ExecutePanelFunction/target
```
ERROR - FAIL - /Actions/Oem/#IBMComputerSystem.v1_0_0.ExecutePanelFunction/target (/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction):
    Action URI Error: The target URI for the action is expected to be '/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.v1_0_0.ExecutePanelFunction'.
```

- /Oem/IBM/ChapData/@odata.type
```
ERROR - FAIL - /Oem/IBM/ChapData/@odata.type ([Not Present]): Required Property Error: The property '@odata.type' is mandatory, but not present in the payload.
```

Tested:
- Redfish Service Validator 3.1.0 passes on those URIs.