### PR TITLE
1210: Aggregation: Add basic authentication support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-01-23T19:00:57Z",
+  "generated_at": "2026-04-06T22:30:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -115,6 +115,16 @@
         "verified_result": null
       }
     ],
+    "http/utility.hpp": [
+      {
+        "hashed_secret": "b2ed08c5b6b837e57e6181bf995a8a72ddb119da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 236,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "include/pam_authenticate.hpp": [
       {
         "hashed_secret": "62d6314bd936033553442d72fe8ce3b93ba8802d",
@@ -190,7 +200,7 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2468,
+        "line_number": 2462,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -200,7 +210,15 @@
         "hashed_secret": "6e069300b0db722cc2ad4b1425a30ff5a8ae20cf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 208,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b1c9af2723f75d3862897604893b1723fb0a93ac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 385,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -338,16 +356,6 @@
         "is_verified": false,
         "line_number": 94,
         "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "redfish-core/schema/oem/openbmc/meson.build": [
-      {
-        "hashed_secret": "74ad61f680f4aa5921a8bf4d95586f3d3e20180e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/http/utility.hpp
+++ b/http/utility.hpp
@@ -230,6 +230,18 @@ inline std::string base64encode(std::string_view data)
     return out;
 }
 
+inline std::string createBasicAuthHeader(std::string_view username,
+                                         std::string_view password)
+{
+    std::string credentials = "Basic ";
+    Base64Encoder enc;
+    enc.encode(username, credentials);
+    enc.encode(":", credentials);
+    enc.encode(password, credentials);
+    enc.finalize(credentials);
+    return credentials;
+}
+
 template <bool urlsafe = false>
 inline bool base64Decode(std::string_view input, std::string& output)
 {

--- a/redfish-core/include/query.hpp
+++ b/redfish-core/include/query.hpp
@@ -167,7 +167,7 @@ inline bool handleIfMatch(crow::App& app, const crow::Request& req,
     if constexpr (BMCWEB_REDFISH_AGGREGATION)
     {
         needToCallHandlers =
-            RedfishAggregator::beginAggregation(req, asyncResp) ==
+            RedfishAggregator::getInstance().beginAggregation(req, asyncResp) ==
             Result::LocalHandle;
 
         // If the request should be forwarded to a satellite BMC then we don't

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -1313,11 +1313,7 @@ class RedfishAggregator
             {
                 // We've matched a resource collection so this current segment
                 // might contain an aggregation prefix
-                // TODO: This needs to be rethought when we can support multiple
-                // satellites due to
-                // /redfish/v1/AggregationService/AggregationSources/5B247A
-                // being a local resource describing the satellite
-                if (collectionItem.starts_with("5B247A_"))
+                if (segmentHasPrefix(collectionItem))
                 {
                     BMCWEB_LOG_DEBUG("Need to forward a request");
 
@@ -1367,6 +1363,32 @@ class RedfishAggregator
 
         BMCWEB_LOG_DEBUG("Aggregation not required for {}", url.buffer());
         return Result::LocalHandle;
+    }
+
+    // Check if the given URL segment matches with any satellite prefix
+    // Assumes the given segment starts with <prefix>_
+    bool segmentHasPrefix(const std::string& urlSegment) const
+    {
+        // TODO: handle this better
+        // For now 5B247A_ wont be in the currentAggregationSources map so
+        // check explicitly for now
+        if (urlSegment.starts_with("5B247A_"))
+        {
+            return true;
+        }
+
+        // Find the first underscore
+        std::size_t underscorePos = urlSegment.find('_');
+        if (underscorePos == std::string::npos)
+        {
+            return false; // No underscore, can't be a satellite prefix
+        }
+
+        // Extract the prefix
+        std::string prefix = urlSegment.substr(0, underscorePos);
+
+        // Check if this prefix exists
+        return currentAggregationSources.contains(prefix);
     }
 };
 

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -587,9 +587,9 @@ class RedfishAggregator
         Resource,
     };
 
-    static void startAggregation(
+    void startAggregation(
         AggregationType aggType, const crow::Request& thisReq,
-        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp) const
     {
         if (thisReq.method() != boost::beast::http::verb::get)
         {
@@ -889,22 +889,29 @@ class RedfishAggregator
         return handler;
     }
 
+    // Aggregation sources from AggregationCollection
+    std::unordered_map<std::string, boost::urls::url> currentAggregationSources;
+
     // Polls D-Bus to get all available satellite config information
     // Expects a handler which interacts with the returned configs
-    static void getSatelliteConfigs(
+    void getSatelliteConfigs(
         std::function<
             void(const boost::system::error_code&,
                  const std::unordered_map<std::string, boost::urls::url>&)>
-            handler)
+            handler) const
     {
         BMCWEB_LOG_DEBUG("Gathering satellite configs");
+
+        std::unordered_map<std::string, boost::urls::url> satelliteInfo(
+            currentAggregationSources);
+
         sdbusplus::message::object_path path("/xyz/openbmc_project/inventory");
         dbus::utility::getManagedObjects(
             "xyz.openbmc_project.EntityManager", path,
-            [handler{std::move(handler)}](
+            [handler{std::move(handler)},
+             satelliteInfo = std::move(satelliteInfo)](
                 const boost::system::error_code& ec,
-                const dbus::utility::ManagedObjectType& objects) {
-                std::unordered_map<std::string, boost::urls::url> satelliteInfo;
+                const dbus::utility::ManagedObjectType& objects) mutable {
                 if (ec)
                 {
                     BMCWEB_LOG_ERROR("DBUS response error {}, {}", ec.value(),
@@ -1261,9 +1268,8 @@ class RedfishAggregator
     // Entry point to Redfish Aggregation
     // Returns Result stating whether or not we still need to locally handle the
     // request
-    static Result beginAggregation(
-        const crow::Request& thisReq,
-        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+    Result beginAggregation(const crow::Request& thisReq,
+                            const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
     {
         using crow::utility::OrMorePaths;
         using crow::utility::readUrlSegments;

--- a/redfish-core/lib/aggregation_service.hpp
+++ b/redfish-core/lib/aggregation_service.hpp
@@ -191,6 +191,19 @@ inline void populateAggregationSource(
     std::string hostName(sat->second.encoded_origin());
     asyncResp->res.jsonValue["HostName"] = std::move(hostName);
 
+    // Include UserName property, defaulting to null
+    auto& aggregator = RedfishAggregator::getInstance();
+    auto it = aggregator.aggregationSources.find(aggregationSourceId);
+    if (it != aggregator.aggregationSources.end() &&
+        !it->second.username.empty())
+    {
+        asyncResp->res.jsonValue["UserName"] = it->second.username;
+    }
+    else
+    {
+        asyncResp->res.jsonValue["UserName"] = nullptr;
+    }
+
     // The Redfish spec requires Password to be null in responses
     asyncResp->res.jsonValue["Password"] = nullptr;
 }
@@ -229,6 +242,36 @@ inline void handleAggregationSourceHead(
                      aggregationSourceId);
 }
 
+inline bool validateCredentialField(const std::optional<std::string>& field,
+                                    const std::string& fieldName,
+                                    crow::Response& res)
+{
+    if (!field.has_value())
+    {
+        return true; // Field not provided, that's okay
+    }
+
+    if (field->empty())
+    {
+        messages::stringValueTooShort(res, fieldName, "1");
+        return false;
+    }
+
+    if (field->find(':') != std::string::npos)
+    {
+        messages::propertyValueIncorrect(res, *field, fieldName);
+        return false;
+    }
+
+    if (field->length() > 40)
+    {
+        messages::stringValueTooLong(res, fieldName, 40);
+        return false;
+    }
+
+    return true;
+}
+
 inline void handleAggregationSourceCollectionPost(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
@@ -238,10 +281,15 @@ inline void handleAggregationSourceCollectionPost(
         return;
     }
     std::string hostname;
-    if (!json_util::readJsonPatch(req, asyncResp->res, "HostName", hostname))
+    std::optional<std::string> username;
+    std::optional<std::string> password;
+
+    if (!json_util::readJsonPatch(req, asyncResp->res, "HostName", hostname,
+                                  "UserName", username, "Password", password))
     {
         return;
     }
+
     boost::system::result<boost::urls::url> url =
         boost::urls::parse_absolute_uri(hostname);
     if (!url)
@@ -256,15 +304,117 @@ inline void handleAggregationSourceCollectionPost(
         return;
     }
     crow::utility::setPortDefaults(*url);
+
+    // Check for duplicate hostname
+    auto& aggregator = RedfishAggregator::getInstance();
+    for (const auto& [existingPrefix, existingSource] :
+         aggregator.aggregationSources)
+    {
+        if (existingSource.url == *url)
+        {
+            messages::resourceAlreadyExists(asyncResp->res, "AggregationSource",
+                                            "HostName", url->buffer());
+            return;
+        }
+    }
+
+    // Validate username and password
+    if (!validateCredentialField(username, "UserName", asyncResp->res))
+    {
+        return;
+    }
+    if (!validateCredentialField(password, "Password", asyncResp->res))
+    {
+        return;
+    }
+
     std::string prefix = bmcweb::getRandomIdOfLength(8);
-    RedfishAggregator::getInstance().currentAggregationSources.emplace(
-        prefix, *url);
+    aggregator.aggregationSources.emplace(
+        prefix,
+        AggregationSource{*url, username.value_or(""), password.value_or("")});
+
     BMCWEB_LOG_DEBUG("Emplaced {} with url {}", prefix, url->buffer());
     asyncResp->res.addHeader(
         boost::beast::http::field::location,
         boost::urls::format("/redfish/v1/AggregationSources/{}", prefix)
             .buffer());
     messages::created(asyncResp->res);
+}
+
+inline void handleAggregationSourcePatch(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& aggregationSourceId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    std::optional<std::string> username;
+    std::optional<std::string> password;
+
+    if (!json_util::readJsonPatch(req, asyncResp->res, "UserName", username,
+                                  "Password", password))
+    {
+        return;
+    }
+
+    // Validate username and password
+    if (!validateCredentialField(username, "UserName", asyncResp->res))
+    {
+        return;
+    }
+    if (!validateCredentialField(password, "Password", asyncResp->res))
+    {
+        return;
+    }
+
+    // Check if the aggregation source exists in writable sources
+    auto& aggregator = RedfishAggregator::getInstance();
+    auto it = aggregator.aggregationSources.find(aggregationSourceId);
+    if (it != aggregator.aggregationSources.end())
+    {
+        // Update only the fields that were provided
+        if (username.has_value())
+        {
+            it->second.username = *username;
+        }
+        if (password.has_value())
+        {
+            it->second.password = *password;
+        }
+
+        messages::success(asyncResp->res);
+        return;
+    }
+
+    // Not in writable sources, query D-Bus to check if it exists in
+    // Entity Manager sources
+    RedfishAggregator::getInstance().getSatelliteConfigs(
+        [asyncResp, aggregationSourceId](
+            const boost::system::error_code& ec,
+            const std::unordered_map<std::string, boost::urls::url>&
+                satelliteInfo) {
+            // Something went wrong while querying dbus
+            if (ec)
+            {
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            // Check if it exists in Entity Manager sources
+            if (satelliteInfo.contains(aggregationSourceId))
+            {
+                // Source exists but is read-only (from Entity Manager)
+                messages::propertyNotWritable(asyncResp->res, "UserName");
+                return;
+            }
+
+            // Doesn't exist anywhere
+            messages::resourceNotFound(asyncResp->res, "AggregationSource",
+                                       aggregationSourceId);
+        });
 }
 
 inline void handleAggregationSourceDelete(
@@ -280,9 +430,8 @@ inline void handleAggregationSourceDelete(
         boost::beast::http::field::link,
         "</redfish/v1/JsonSchemas/AggregationService/AggregationSource.json>; rel=describedby");
 
-    size_t deleted =
-        RedfishAggregator::getInstance().currentAggregationSources.erase(
-            aggregationSourceId);
+    size_t deleted = RedfishAggregator::getInstance().aggregationSources.erase(
+        aggregationSourceId);
     if (deleted == 0)
     {
         messages::resourceNotFound(asyncResp->res, "AggregationSource",
@@ -300,6 +449,12 @@ inline void requestRoutesAggregationSource(App& app)
         .privileges(redfish::privileges::getAggregationSource)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleAggregationSourceGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/AggregationService/AggregationSources/<str>/")
+        .privileges(redfish::privileges::patchAggregationSource)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleAggregationSourcePatch, std::ref(app)));
 
     BMCWEB_ROUTE(app,
                  "/redfish/v1/AggregationService/AggregationSources/<str>/")

--- a/redfish-core/lib/aggregation_service.hpp
+++ b/redfish-core/lib/aggregation_service.hpp
@@ -242,7 +242,6 @@ inline void handleAggregationSourceCollectionPost(
     {
         return;
     }
-
     boost::system::result<boost::urls::url> url =
         boost::urls::parse_absolute_uri(hostname);
     if (!url)
@@ -257,16 +256,14 @@ inline void handleAggregationSourceCollectionPost(
         return;
     }
     crow::utility::setPortDefaults(*url);
-
     std::string prefix = bmcweb::getRandomIdOfLength(8);
     RedfishAggregator::getInstance().currentAggregationSources.emplace(
         prefix, *url);
-
+    BMCWEB_LOG_DEBUG("Emplaced {} with url {}", prefix, url->buffer());
     asyncResp->res.addHeader(
         boost::beast::http::field::location,
         boost::urls::format("/redfish/v1/AggregationSources/{}", prefix)
             .buffer());
-
     messages::created(asyncResp->res);
 }
 

--- a/redfish-core/lib/aggregation_service.hpp
+++ b/redfish-core/lib/aggregation_service.hpp
@@ -8,16 +8,22 @@
 #include "http_request.hpp"
 #include "http_response.hpp"
 #include "logging.hpp"
+#include "ossl_random.hpp"
 #include "query.hpp"
 #include "redfish_aggregator.hpp"
 #include "registries/privilege_registry.hpp"
+#include "utility.hpp"
+#include "utils/json_utils.hpp"
 
 #include <boost/beast/http/field.hpp>
 #include <boost/beast/http/verb.hpp>
+#include <boost/system/result.hpp>
 #include <boost/url/format.hpp>
+#include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
 #include <nlohmann/json.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <unordered_map>
@@ -114,7 +120,7 @@ inline void handleAggregationSourceCollectionGet(
     json["Name"] = "Aggregation Source Collection";
 
     // Query D-Bus for satellite configs and add them to the Members array
-    RedfishAggregator::getSatelliteConfigs(
+    RedfishAggregator::getInstance().getSatelliteConfigs(
         std::bind_front(populateAggregationSourceCollection, asyncResp));
 }
 
@@ -201,7 +207,7 @@ inline void handleAggregationSourceGet(
 
     // Query D-Bus for satellite config corresponding to the specified
     // AggregationSource
-    RedfishAggregator::getSatelliteConfigs(std::bind_front(
+    RedfishAggregator::getInstance().getSatelliteConfigs(std::bind_front(
         populateAggregationSource, aggregationSourceId, asyncResp));
 }
 
@@ -223,6 +229,73 @@ inline void handleAggregationSourceHead(
                      aggregationSourceId);
 }
 
+inline void handleAggregationSourceCollectionPost(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    std::string hostname;
+    if (!json_util::readJsonPatch(req, asyncResp->res, "HostName", hostname))
+    {
+        return;
+    }
+
+    boost::system::result<boost::urls::url> url =
+        boost::urls::parse_absolute_uri(hostname);
+    if (!url)
+    {
+        messages::propertyValueIncorrect(asyncResp->res, hostname, "HostName");
+        return;
+    }
+    url->normalize();
+    if (url->scheme() != "http" && url->scheme() != "https")
+    {
+        messages::propertyValueIncorrect(asyncResp->res, hostname, "HostName");
+        return;
+    }
+    crow::utility::setPortDefaults(*url);
+
+    std::string prefix = bmcweb::getRandomIdOfLength(8);
+    RedfishAggregator::getInstance().currentAggregationSources.emplace(
+        prefix, *url);
+
+    asyncResp->res.addHeader(
+        boost::beast::http::field::location,
+        boost::urls::format("/redfish/v1/AggregationSources/{}", prefix)
+            .buffer());
+
+    messages::created(asyncResp->res);
+}
+
+inline void handleAggregationSourceDelete(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& aggregationSourceId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    asyncResp->res.addHeader(
+        boost::beast::http::field::link,
+        "</redfish/v1/JsonSchemas/AggregationService/AggregationSource.json>; rel=describedby");
+
+    size_t deleted =
+        RedfishAggregator::getInstance().currentAggregationSources.erase(
+            aggregationSourceId);
+    if (deleted == 0)
+    {
+        messages::resourceNotFound(asyncResp->res, "AggregationSource",
+                                   aggregationSourceId);
+        return;
+    }
+
+    messages::success(asyncResp->res);
+}
+
 inline void requestRoutesAggregationSource(App& app)
 {
     BMCWEB_ROUTE(app,
@@ -230,6 +303,23 @@ inline void requestRoutesAggregationSource(App& app)
         .privileges(redfish::privileges::getAggregationSource)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleAggregationSourceGet, std::ref(app)));
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/AggregationService/AggregationSources/<str>/")
+        .privileges(redfish::privileges::deleteAggregationSource)
+        .methods(boost::beast::http::verb::delete_)(
+            std::bind_front(handleAggregationSourceDelete, std::ref(app)));
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/AggregationService/AggregationSources/<str>/")
+        .privileges(redfish::privileges::headAggregationSource)
+        .methods(boost::beast::http::verb::head)(
+            std::bind_front(handleAggregationSourceHead, std::ref(app)));
+
+    BMCWEB_ROUTE(app, "/redfish/v1/AggregationService/AggregationSources/")
+        .privileges(redfish::privileges::postAggregationSourceCollection)
+        .methods(boost::beast::http::verb::post)(std::bind_front(
+            handleAggregationSourceCollectionPost, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
Add support for basic authentication when connecting to aggregation
sources. This allows satellite BMCs to be authenticated using
username and password credentials.

The implementation:
- Stores credentials alongside URLs in AggregationSource struct
- Validates credentials: no colons, max 40 chars, not empty strings
- Creates Basic Auth headers using base64 encoding
- Only sends Authorization header when both username and password exist
- Adds PATCH handler for updating credentials independently
- Prevents duplicate aggregation sources with same hostname
- Cleans up credentials when aggregation sources are deleted

Tested: Manual testing with authenticated aggregation sources

Example commands succeed, and return the expected results.
```
curl --insecure -H "Content-Type: application/json" -X POST -D headers.txt https://$bmc/redfish/v1/AggregationService/AggregationSources/ -d '{"HostName": "https://9.3.29.130/", "UserName" :"<username>", "Password":  "<password>"}' -H "X-Auth-Token: $token"

{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The resource was created successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Created",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}

$curl -k  -X GET https://${bmc}/redfish/v1/Systems -H "X-Auth-Token: $token"

{
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/hypervisor"
    },
    {
      "@odata.id": "/redfish/v1/Systems/oRQfDGjh_system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/oRQfDGjh_hypervisor"
    }
  ],
  "Members@odata.count": 4,
  "Name": "Computer System Collection"
}

$curl -k  -X GET https://${bmc}/redfish/v1/Managers -H "X-Auth-Token: $token"

{
  "@odata.id": "/redfish/v1/Managers",
  "@odata.type": "#ManagerCollection.ManagerCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Managers/bmc"
    },
    {
      "@odata.id": "/redfish/v1/Managers/oRQfDGjh_bmc"
    }
  ],
  "Members@odata.count": 2,
  "Name": "Manager Collection"
}
```

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/84143

Change-Id: Ide17a3c08a4a8f6b90a2ffcd2c798cbbec578db8

**Allow POST on aggregation sources**
It would be useful for both testing and production if one could create aggregation sources dynamically, rather than using detected hardware. Redfish sources might exist outside of the physical chassis in a way that's detectable, so giving DC software a way to set up a non-trivial aggregation topology make this more extensible.

Note, that as documented in AGGREGATION.md, only a single satellite is supported by this feature.  This patch does not change that behavior, and implementing an entity-manager satellite will override a POST created AggregationSource.

Tested:

Example commands succeed, and return the expected results.
```
curl -vvvv -k --http1.1 --user "root:0penBmc" --request DELETE https://192.168.7.2/redfish/v1/AggregationService/AggregationSources/
curl -vvvv -k --http1.1 --user "root:0penBmc" https://192.168.7.2/redfish/v1/AggregationService/AggregationSources -H "Content-Type: application/json" --request POST --data '{"HostName":"https://localhost:8000"}'
```

Redfish service validator passes.

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71840

Change-Id: I15711c3075645291b5f2555eefb80bb80418e7e5

**Enable satellite aggregation over POST**
This patch enables Redfish satellite aggregation through REST API
POST requests to /redfish/v1/AggregationService/AggregationSources.
Tested successfully on ubuntu22 using multiple python redfish mockup
servers as satellite bmcs.

The previous urlHasPrefix function incorrectly assumed it would receive
a full URL path, but it actually receives individual URL segments.
Replaced with segmentHasPrefix that vastly simplifies prefix matching
in the currentAggregationSources map.

Also removed the correct duplicated route in
redfish-core/lib/aggregation_service.hpp that was causing routing
conflicts.

The hardcoded 5B247A_ fallback remains temporarily and will be
addressed in change 83181 which adds D-Bus satellite support.

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/83180

Change-Id: I41920ad270abe4b228b43280ea425b80d3f14b50
