### PR TITLE
1210: Correct a confusing debug message about Aggregation

### DIFF
--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -927,7 +927,7 @@ class RedfishAggregator
                 else
                 {
                     BMCWEB_LOG_DEBUG(
-                        "No satellite BMCs detected.  Redfish Aggregation not enabled");
+                        "Redfish aggregation enabled, but no satellite BMCs detected");
                 }
                 handler(ec, satelliteInfo);
             });


### PR DESCRIPTION
The previous message indicated that Aggregation is not enabled. It is a case where aggregation is enabled, but there are no satellite BMCs. The new debug message indicates that.

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/88883 
Change-Id: I1aebfd6f771ae81ceb30a506c9bdd8fcc35c77d1