### PR TITLE
Software: Add D-Bus trace when internalError

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -1385,6 +1385,7 @@ inline void getSoftwareVersion(
                const dbus::utility::DBusPropertiesMap& propertiesList) {
             if (ec)
             {
+                BMCWEB_LOG_ERROR("D-Bus error {}", ec);
                 messages::internalError(asyncResp->res);
                 return;
             }
@@ -1465,6 +1466,7 @@ inline void handleUpdateServiceFirmwareInventoryGet(
             BMCWEB_LOG_DEBUG("doGet callback...");
             if (ec)
             {
+                BMCWEB_LOG_ERROR("D-Bus error {}", ec);
                 messages::internalError(asyncResp->res);
                 return;
             }


### PR DESCRIPTION
Hit an internalError in a defect, having the ec would have been useful. Do that. Follow our Error Logging Levels.[1]

Added a 2nd trace for another place in update_service.hpp.

[1]: https://github.com/openbmc/bmcweb/blob/2bd69f6557d59391a236f9bdf61b7a6d4b77f295/DEVELOPING.md?plain=1#L224

Tested: Built bmcweb. Did not force down this error path.

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/89128 but upstream has had a solid refactor since 

Defect is https://jazz07.rchland.ibm.com:13443/jazz/web/projects/CSSD#action=com.ibm.team.workitem.viewWorkItem&id=775864