### PR TITLE
redfish: Add OEM BMC Pairing schema for IBM

### DIFF
--- a/redfish-core/schema/oem/ibm/csdl/OemBmcPairing_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/OemBmcPairing_v1.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:Reference
+        Uri="http://docs.oasis-open.org/odata/odata/v4.0/errata03/csd01/complete/vocabularies/Org.OData.Core.V1.xml">
+        <edmx:Include Namespace="Org.OData.Core.V1" Alias="OData" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/Manager_v1.xml">
+        <edmx:Include Namespace="Manager" />
+        <edmx:Include Namespace="Manager.v1_15_0.Manager" />
+    </edmx:Reference>
+    <edmx:Reference Uri="http://redfish.dmtf.org/schemas/v1/RedfishExtensions_v1.xml">
+        <edmx:Include Namespace="RedfishExtensions.v1_0_0" Alias="Redfish" />
+    </edmx:Reference>
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemBmcPairing">
+            <Annotation Term="Redfish.OwningEntity" String="IBM" />
+        </Schema>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemBmcPairing.v1_0_0">
+            <ComplexType Name="BmcPairing">
+                <Annotation Term="OData.AdditionalProperties" Bool="false" />
+                <Annotation Term="OData.Description" String="BMC Pairing information." />
+                <Annotation Term="OData.LongDescription"
+                    String="This type shall contain information about the BMC pairing status." />
+                <Property Name="Paired" Type="Edm.Boolean">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read" />
+                    <Annotation Term="OData.Description"
+                        String="Indicates whether this BMC is paired with another BMC." />
+                    <Annotation Term="OData.LongDescription"
+                        String="This property shall indicate whether this BMC is currently paired with another BMC. A value of true indicates the BMC is paired, false indicates it is not paired." />
+                </Property>
+                <Property Name="AvailableBmcs" Type="Collection(Edm.String)">
+                    <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read" />
+                    <Annotation Term="OData.Description"
+                        String="The names of BMCs that are available for pairing." />
+                    <Annotation Term="OData.LongDescription"
+                        String="This property shall contain an array of names of BMCs that are discovered and available for pairing with this BMC. This array may be empty if no BMCs are currently available for pairing." />
+                </Property>
+            </ComplexType>
+            <Action Name="Pair" IsBound="true">
+                <Annotation Term="OData.Description"
+                    String="This action pairs this BMC with another BMC." />
+                <Annotation Term="OData.LongDescription"
+                    String="This action shall establish a pairing relationship between this BMC and the specified target BMC." />
+                <Parameter Name="Manager" Type="Manager.v1_0_0.OemActions" />
+                <Parameter Name="BmcName" Type="Edm.String" Nullable="false">
+                    <Annotation Term="OData.Description" String="The name of the BMC to pair with." />
+                    <Annotation Term="OData.LongDescription"
+                        String="This parameter shall contain the name or identifier of the BMC to establish pairing with." />
+                </Parameter>
+            </Action>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.json
+++ b/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.json
@@ -1,0 +1,8 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2026 OpenBMC.",
+    "definitions": {},
+    "owningEntity": "IBM",
+    "title": "#OemBmcPairing"
+}

--- a/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.v1_0_0.json
@@ -1,0 +1,84 @@
+{
+    "$id": "https://github.com/ibm-openbmc/bmcweb/tree/HEAD/redfish-core/schema/oem/ibm/json-schema/OemBmcPairing.v1_0_0.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "Copyright": "Copyright 2026 OpenBMC.",
+    "definitions": {
+        "BmcPairing": {
+            "additionalProperties": false,
+            "description": "BMC Pairing information",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Paired": {
+                    "description": "Indicates whether this BMC is paired with another BMC",
+                    "longDescription": "This property shall indicate whether this BMC is currently paired with another BMC. A value of true indicates the BMC is paired, false indicates it is not paired.",
+                    "type": "boolean",
+                    "readonly": true
+                },
+                "AvailableBmcs": {
+                    "description": "The names of BMCs that are available for pairing",
+                    "longDescription": "This property shall contain an array of names of BMCs that are discovered and available for pairing with this BMC. This array may be empty if no BMCs are currently available for pairing.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "Pair": {
+            "additionalProperties": false,
+            "description": "This action pairs this BMC with another BMC",
+            "parameters": {
+                "BmcName": {
+                    "description": "The name of the BMC to pair with",
+                    "longDescription": "This parameter shall contain the name or identifier of the BMC to establish pairing with.",
+                    "requiredParameter": true,
+                    "type": "string"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "OwningEntity": "OpenBMC",
+    "release": "1.0",
+    "title": "#OemBmcPairing.v1_0_0"
+}

--- a/redfish-core/schema/oem/ibm/meson.build
+++ b/redfish-core/schema/oem/ibm/meson.build
@@ -8,6 +8,7 @@ schemas = [
     'IBMPCIeDevice',
     'IBMPCIeSlots',
     'IBMServiceRoot',
+    'OemBmcPairing',
     'OemUpdateService',
 ]
 


### PR DESCRIPTION
Add OemBmcPairing schema to support BMC pairing functionality. This includes:
- CSDL schema definition (OemBmcPairing_v1.xml)
- JSON schema files (OemBmcPairing.json and OemBmcPairing.v1_0_0.json)
- Meson build configuration update

The schema defines:
- BmcPairing complex type with Paired status and AvailableBmcs list
- Pair action to establish pairing between BMCs

This enables discovery and pairing of multiple BMCs in the system.