### PR TITLE
1210: Aggregation: Fix idefinite aggregation loop

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-06T22:30:34Z",
+  "generated_at": "2026-04-14T17:52:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -187,6 +187,16 @@
         "verified_result": null
       }
     ],
+    "redfish-core/include/redfish_aggregator.hpp": [
+      {
+        "hashed_secret": "6303c901093123ff7019188dcd12b2e18d4d9827",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 452,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "redfish-core/lib/account_service.hpp": [
       {
         "hashed_secret": "5ef4ffb79f46bdb334115d166dd092402bdf6c13",
@@ -256,7 +266,7 @@
         "hashed_secret": "efb7b9c519415e44a5f30819aaa9bf534f6afb27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2301,
+        "line_number": 2302,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/redfish-core/include/redfish_aggregator.hpp
+++ b/redfish-core/include/redfish_aggregator.hpp
@@ -425,9 +425,10 @@ class RedfishAggregator
   private:
     crow::HttpClient client;
 
-    // Dummy callback used by the Constructor so that it can report the number
+    // callback used by the Constructor to report the number
     // of satellite configs when the class is first created
-    static void constructorCallback(
+    // Fills default aggregationSources with satellite information
+    void constructorCallback(
         const boost::system::error_code& ec,
         const std::unordered_map<std::string, boost::urls::url>& satelliteInfo)
     {
@@ -439,6 +440,18 @@ class RedfishAggregator
 
         BMCWEB_LOG_DEBUG("There were {} satellite configs found at startup",
                          std::to_string(satelliteInfo.size()));
+        // Update aggregationSources with satellite information
+        for (const auto& [name, url] : satelliteInfo)
+        {
+            AggregationSource source;
+            source.url = url;
+            // Enhancement can be added to fetch username and password
+            // from some secure sources. Currently satellite configuration
+            // supports only NONE
+            source.username = "";
+            source.password = "";
+            aggregationSources[name] = std::move(source);
+        }
     }
 
     // Search D-Bus objects for satellite config objects and add their
@@ -456,16 +469,6 @@ class RedfishAggregator
                 {
                     BMCWEB_LOG_DEBUG("Found Satellite Controller at {}",
                                      objectPath.first.str);
-
-                    if (!satelliteInfo.empty())
-                    {
-                        BMCWEB_LOG_ERROR(
-                            "Redfish Aggregation only supports one satellite!");
-                        BMCWEB_LOG_DEBUG("Clearing all satellite data");
-                        satelliteInfo.clear();
-                        return;
-                    }
-
                     addSatelliteConfig(interface.second, satelliteInfo);
                 }
             }
@@ -511,7 +514,6 @@ class RedfishAggregator
                 }
                 url.set_port(std::to_string(static_cast<uint16_t>(*propVal)));
             }
-
             else if (prop.first == "AuthType")
             {
                 const std::string* propVal =
@@ -527,7 +529,7 @@ class RedfishAggregator
                 if (*propVal != "None")
                 {
                     BMCWEB_LOG_ERROR(
-                        "Unsupported AuthType value: {}, only \"none\" is supported",
+                        "Unsupported AuthType value: {}, only \"None\" is supported",
                         *propVal);
                     return;
                 }
@@ -615,19 +617,8 @@ class RedfishAggregator
             }
         }
 
-        // Create a copy of thisReq so we we can still locally process the req
-        std::error_code ec;
         auto localReq = std::make_shared<crow::Request>(thisReq.copy());
-        if (ec)
-        {
-            BMCWEB_LOG_ERROR("Failed to create copy of request");
-            if (aggType == AggregationType::Resource)
-            {
-                messages::internalError(asyncResp->res);
-            }
-            return;
-        }
-
+        localReq->addHeader("X-Forwarded-For", "bmcweb");
         if (aggType == AggregationType::Collection)
         {
             boost::urls::url& urlNew = localReq->url();
@@ -896,7 +887,8 @@ class RedfishAggregator
         client(getIoContext(),
                std::make_shared<crow::ConnectionPolicy>(getAggregationPolicy()))
     {
-        getSatelliteConfigs(constructorCallback);
+        getSatelliteConfigs(
+            std::bind_front(&RedfishAggregator::constructorCallback, this));
     }
     RedfishAggregator(const RedfishAggregator&) = delete;
     RedfishAggregator& operator=(const RedfishAggregator&) = delete;
@@ -1326,7 +1318,19 @@ class RedfishAggregator
         using crow::utility::OrMorePaths;
         using crow::utility::readUrlSegments;
         boost::urls::url_view url = thisReq.url();
-
+        BMCWEB_LOG_DEBUG("Checking if aggregation is required for {}",
+                         thisReq.target().data());
+        // keeping forwarded for bmcweb right now. This is sufficient for fully
+        //  connected bmc topology for mutual aggregation and deduplication.
+        // The property can be enhanced to support for different bmc topologies
+        // in future.
+        auto forwardedHeader = thisReq.getHeaderValue("X-Forwarded-For");
+        if (!forwardedHeader.empty() && forwardedHeader == "bmcweb")
+        {
+            BMCWEB_LOG_DEBUG(
+                "Already handled request, skipping remote aggregation");
+            return Result::LocalHandle;
+        }
         // We don't need to aggregate JsonSchemas due to potential issues such
         // as version mismatches between aggregator and satellite BMCs.  For
         // now assume that the aggregator has all the schemas and versions that
@@ -1438,7 +1442,6 @@ class RedfishAggregator
 
         // Extract the prefix
         std::string prefix = urlSegment.substr(0, underscorePos);
-
         // Check if this prefix exists
         return aggregationSources.contains(prefix);
     }


### PR DESCRIPTION
Any bmc should be able to aggregate resources from its peers.
Bmcweb will be compiled with aggregation enabled for both satellite and master BMCs. Bmcweb should be able to distinguish between the requests originated from its peer BMC and external redfish clients. Otherwise aggregation will end up in indefinite aggregation loop.

This commit will add extra header to identify the aggregation request from peers.
This implementation assumes that any type of transitive aggregation is not present( A aggregates B aggregates C etc).
If we have such requirement then we can enhance header property to hold all parent bmc information to filter and avoid any aggregation loop.

This cherry-picks only includes the changes to fix the issue with indefinite aggregation loop. It doesn't include the changes for
MTLS support.

Tested By:
bmc and bmc2 are satellites of each other.
curl -k  -X GET https://${bmc}/redfish/v1/Systems -H "X-Auth-Token: $token" {
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/hypervisor"
    },
    {
      "@odata.id": "/redfish/v1/Systems/9Ilut4vH_system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/9Ilut4vH_hypervisor"
    },
    {
      "@odata.id": "/redfish/v1/Systems/CNaH0ljH_system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/CNaH0ljH_hypervisor"
    }
  ],
  "Members@odata.count": 6,
  "Name": "Computer System Collection"

curl -k  -X GET https://${bmc2}/redfish/v1/Systems -H "X-Auth-Token: $token2"
{
  "@odata.id": "/redfish/v1/Systems",
  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
  "Members": [
    {
      "@odata.id": "/redfish/v1/Systems/system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/hypervisor"
    },
    {
      "@odata.id": "/redfish/v1/Systems/tJmMBoFD_system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/tJmMBoFD_hypervisor"
    },
    {
      "@odata.id": "/redfish/v1/Systems/bI7Gq7VR_system"
    },
    {
      "@odata.id": "/redfish/v1/Systems/bI7Gq7VR_hypervisor"
    }
  ],
  "Members@odata.count": 6,
  "Name": "Computer System Collection"

https://gerrit.openbmc.org/c/openbmc/bmcweb/+/71685

