### PR TITLE
1210: Move body limit enforcement (#1439)

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -698,6 +698,13 @@ class Connection :
                 ip, res, method, value.base(), mtlsSession);
         }
 
+        if (!handleContentLengthError())
+        {
+            return;
+        }
+
+        parse.body_limit(getContentLengthLimit());
+
         std::string_view expect = value[boost::beast::http::field::expect];
         if (bmcweb::asciiIEquals(expect, "100-continue"))
         {
@@ -705,13 +712,6 @@ class Connection :
             doWrite();
             return;
         }
-
-        if (!handleContentLengthError())
-        {
-            return;
-        }
-
-        parse.body_limit(getContentLengthLimit());
 
         if (parse.is_done())
         {


### PR DESCRIPTION
#### Move body limit enforcement (#1439)
```
Make sure the body limit enforcement happens before the Expect:
100-continue check.

Tested: Verified the body limit check happens first, even when Expect:
        100-continue is used. Now rejects with 413 Payload Too Large.
        Normal operations such as the Redfish Validator still work.

Change-Id: I185dab82c75b3c44d89102750fd03666659a57a6

Signed-off-by: Gunnar Mills <gmills@us.ibm.com>```