### PR TITLE
Audit Log: Skip detail for LogService.CollectDiagnosticData

### DIFF
--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -121,7 +121,8 @@ inline bool checkSkipDetail(const crow::Request& req)
            req.target().starts_with("/redfish/v1/UpdateService") ||
            req.target().starts_with("/ibm/v1") ||
            ((req.method() == boost::beast::http::verb::post) &&
-            checkPostUser(req));
+            (checkPostUser(req) ||
+             req.target().contains("LogService.CollectDiagnosticData")));
 }
 
 /**

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -154,6 +154,14 @@ TEST(wantDetail, NegativeTest)
         "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate");
     EXPECT_FALSE(wantDetail(postRequest));
 
+    postRequest.target(
+        "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target(
+        "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
     crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
     EXPECT_FALSE(wantDetail(getRequest));
 }


### PR DESCRIPTION
The LogService.CollectDiagnosticData Redfish routes contain user login information encoded in the data. This should not be included in an audit log entry.

Tested: WIP