### PR TITLE
Backport 1110 DoS recovery to 1060

### DIFF
--- a/http/http_connection.hpp
+++ b/http/http_connection.hpp
@@ -672,9 +672,16 @@ class Connection :
             readClientIp();
 
             boost::asio::ip::address ip;
-            if (getClientIp(ip))
+            boost::system::error_code errCode = getClientIp(ip);
+            if (errCode)
             {
                 BMCWEB_LOG_DEBUG << "Unable to get client IP";
+                if (errCode == boost::asio::error::not_connected)
+                {
+                    close();
+                    BMCWEB_LOG_ERROR << this << " socket not connected";
+                    return;
+                }
             }
             sessionIsFromTransport = false;
 #ifndef BMCWEB_INSECURE_DISABLE_AUTHX
@@ -743,6 +750,13 @@ class Connection :
 
             if (ec)
             {
+                if (ec == boost::beast::http::error::end_of_stream ||
+                    ec == boost::asio::ssl::error::stream_truncated)
+                {
+                    BMCWEB_LOG_WARNING << this << " end of stream: " << ec;
+                    close();
+                    return;
+                }
                 BMCWEB_LOG_DEBUG << this << " from write(2)";
                 return;
             }


### PR DESCRIPTION
Change: Catch ENOTCONN error and close socket if error occurs
- Upstream changes and 1110 are https://github.com/ibm-openbmc/bmcweb/pull/1311

Problem:
- BMC takes several minutes to close connections when client does not follow TLS protocol for `close_notify`.
- 1110 and upstream has `hardClose()` for clients not following protocol. 1060 already hard closes the connection by default with `adaptor.close()` or `adaptor.next_layer().close()`

Tested:
- Ran DoS script where it does not send `close_notify` against bmcweb for both unauthenticated and authenticated requests on 1060 firmware on the test systems

Observations:
- The BMC became unresponsive for 60-90s before any new request was able to get through
- It took around 60-90s for the sockets to move from `CLOSE_WAIT` state to `LAST_ACK` -