### PR TITLE
Fix CI: Reformat using Black 26.1.0

### DIFF
--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -19,10 +19,7 @@ WARNING = """/****************************************************************
  * github organization.
  ***************************************************************/"""
 
-REGISTRY_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+REGISTRY_HEADER = PRAGMA_ONCE + WARNING + """
 #include "registries.hpp"
 
 #include <array>
@@ -32,7 +29,6 @@ REGISTRY_HEADER = (
 namespace redfish::registries::{}
 {{
 """
-)
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -173,10 +169,7 @@ def create_Subordinate_Overrides(target_list):
     return target_list_create
 
 
-PRIVILEGE_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+PRIVILEGE_HEADER = PRAGMA_ONCE + WARNING + """
 #include "privileges.hpp"
 
 #include <array>
@@ -186,7 +179,6 @@ PRIVILEGE_HEADER = (
 namespace redfish::privileges
 {
 """
-)
 
 
 def make_privilege_registry():


### PR DESCRIPTION
CI is failing due to the formatting of scripts/parse_registries.py. Run Black.
CI is failing at #1447 

black -l 79 <filename>

Just like https://github.com/ibm-openbmc/bmcweb/pull/1392

Upstream is https://gerrit.openbmc.org/c/openbmc/bmcweb/+/86790

Current:
    Running black (black, 26.1.0 (compiled: no))
reformatted scripts/parse_registries.py

Before:
    Running black (black, 25.12.0 (compiled: no))

Tested: Visual only.

Change-Id: I08051019760994a095eeedab2ae0d8c91984e979