### PR TITLE
Audit Log: Skip detail for LogService.CollectDiagnosticData (#1441)

### DIFF
--- a/include/audit_events.hpp
+++ b/include/audit_events.hpp
@@ -146,7 +146,9 @@ inline bool checkSkipDetail(const crow::Request& req)
     if (req.target().starts_with("/redfish/v1/AccountService/Accounts") ||
         req.target().starts_with("/ibm/v1") ||
         ((req.method() == boost::beast::http::verb::post) &&
-         checkPostUser(req)))
+         (checkPostUser(req) ||
+          (req.target().find("LogService.CollectDiagnosticData") !=
+           std::string::npos))))
     {
         return true;
     }

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -144,6 +144,14 @@ TEST(wantDetail, NegativeTest)
     postRequest.target("/login");
     EXPECT_FALSE(wantDetail(postRequest));
 
+    postRequest.target(
+        "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target(
+        "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
     crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};
     EXPECT_FALSE(wantDetail(getRequest));
 }


### PR DESCRIPTION
The LogService.CollectDiagnosticData Redfish routes contain user login information encoded in the data. This should not be included in an audit log entry.

Example of problem:

```
type=USYS_CONFIG msg=audit(04/29/26 16:15:55.759:20) : pid=1170 uid=root auid=unset ses=unset msg='op=POST:/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData/ {"DiagnosticDataType":"OEM","OEMDiagnosticDataType":"Resource_service_Mypasswd!"} acct=service exe=/usr/bin/bmcweb hostname=p11bmc addr=::ffff:10.0.2.1 terminal=? res=failed'
```
Tested:
 - Confirmed audit log entry for Redfish route URI does not contain the password. Confirmed both with and without the trailing '\'.

```
type=USYS_CONFIG msg=audit(04/29/26 16:16:31.359:23) : pid=1706 uid=root auid=service ses=7 msg='op=POST:/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData/ acct=service exe=/tmp/bmcweb hostname=p11bmc addr=10.0.2.1 terminal=? res=failed'
----
type=USYS_CONFIG msg=audit(04/29/26 16:16:38.009:24) : pid=1706 uid=root auid=service ses=7 msg='op=POST:/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData acct=service exe=/tmp/bmcweb hostname=p11bmc addr=10.0.2.1 terminal=? res=failed'
```

Fixes defect 778656