### PR TITLE
1120: Change a few message responses as errors

### DIFF
--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -204,7 +204,7 @@ void propertyValueFormatError(crow::Response& res, const nlohmann::json& arg1,
                               std::string_view arg2)
 {
     res.result(boost::beast::http::status::bad_request);
-    addMessageToJson(res.jsonValue, propertyValueFormatError(arg1, arg2), arg2);
+    addMessageToErrorJson(res.jsonValue, propertyValueFormatError(arg1, arg2));
 }
 
 /**
@@ -928,8 +928,8 @@ void resourceAlreadyExists(crow::Response& res, std::string_view arg1,
                            std::string_view arg2, std::string_view arg3)
 {
     res.result(boost::beast::http::status::conflict);
-    addMessageToJson(res.jsonValue, resourceAlreadyExists(arg1, arg2, arg3),
-                     arg2);
+    addMessageToErrorJson(res.jsonValue,
+                          resourceAlreadyExists(arg1, arg2, arg3));
 }
 
 /**

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -401,9 +401,7 @@ def make_error_function(
 
             addMessageToJson = {
                 "PropertyDuplicate": 1,
-                "ResourceAlreadyExists": 2,
                 "CreateFailedMissingReqProperties": 1,
-                "PropertyValueFormatError": 2,
                 "PropertyValueNotInList": 2,
                 "PropertyValueTypeError": 2,
                 "PropertyValueError": 1,


### PR DESCRIPTION
Some of messages are not currently reported as errors, although they are the results as Redfish request errors. Those include

- ResourceAlreadyExists
- PropertyValueFormatError

For example, PropertyValueFormatError is currently not treated as an error. It shows like

```

curl -k -X PATCH "${bmc}/redfish/v1/AccountService/Accounts/admin" \
  -H "Content-Type: application/json" \
  -d '{ "Password": "" }'

  "Password@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'null' for the property Password is not a format that the property can accept.",
      "MessageArgs": [
        "null",
        "Password"
      ],
      "MessageId": "Base.1.19.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
```

After making it as an error, it will be like
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The value 'null' for the property Password is not a format that the property can accept.",
        "MessageArgs": [
          "null",
          "Password"
        ],
        "MessageId": "Base.1.19.PropertyValueFormatError",
        "MessageSeverity": "Warning",
        "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.PropertyValueFormatError",
    "message": "The value 'null' for the property Password is not a format that the property can accept."
  }
}
```

Tested:
- Check those response messages

Change-Id: I746c55e42e8f0cde205a3800e3da17cd78cf7e34