### PR TITLE
1120: Prevent ReadOnly user to escate privilege to Admin

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2754,6 +2754,19 @@ inline bool handleOemPatch(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     }
     return true;
 }
+
+inline bool ensurePrivilegedProperties(
+    const std::optional<std::string>& newUserName,
+    const std::optional<std::string>& password,
+    const std::optional<bool>& enabled,
+    const std::optional<std::string>& roleId, const std::optional<bool>& locked,
+    const std::optional<std::vector<std::string>>& accountTypes,
+    const std::optional<std::vector<std::string>>& mfaBypass)
+{
+    return !(newUserName || password || enabled || roleId || locked ||
+             accountTypes || mfaBypass);
+}
+
 inline void handleAccountPatch(
     App& app, const crow::Request& req,
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2792,6 +2805,15 @@ inline void handleAccountPatch(
         // If user is service
         if (oem)
         {
+            if (!ensurePrivilegedProperties(newUserName, password, enabled,
+                                            roleId, locked, accountTypes,
+                                            mfaBypass))
+            {
+                BMCWEB_LOG_WARNING(
+                    "Unauthenticated users are never allowed to PATCH anything other than the \"Oem\" property");
+                messages::insufficientPrivilege(asyncResp->res);
+                return;
+            }
             handleOemPatch(asyncResp, *oem, req, username, true);
             return;
         }
@@ -2810,6 +2832,15 @@ inline void handleAccountPatch(
     {
         if (oem)
         {
+            if (!ensurePrivilegedProperties(newUserName, password, enabled,
+                                            roleId, locked, accountTypes,
+                                            mfaBypass))
+            {
+                BMCWEB_LOG_WARNING(
+                    "Unauthenticated users are never allowed to PATCH anything other than the \"Oem\" property");
+                messages::insufficientPrivilege(asyncResp->res);
+                return;
+            }
             handleOemPatch(asyncResp, *oem, req, username, true);
             return;
         }
@@ -2820,16 +2851,17 @@ inline void handleAccountPatch(
             messages::insufficientPrivilege(asyncResp->res);
             return;
         }
-        // Read only users should not be allowed to bypass self
-        if (mfaBypass)
+        // Read only users should not be allowed to bypass self, except the
+        // password change
+        if (!ensurePrivilegedProperties(newUserName, std::nullopt, enabled,
+                                        roleId, locked, accountTypes,
+                                        mfaBypass))
         {
             BMCWEB_LOG_WARNING(
-                "User has insufficient privilege to bypass self");
+                "User does not have authority to PATCH anything other than Password");
             messages::insufficientPrivilege(asyncResp->res);
             return;
         }
-        // NOTE: password was already obtained from the previous
-        // readJsonPatch().
     }
 
     // For accounts which have a Restricted Role, restrict which properties


### PR DESCRIPTION
A Redfish user with RoleID as ReadOnly is able to update its own role as Administrator. This causes the privilege escalation to the greater authorities.  It should be rejected as HTTP 403 error.

Tested:
- PATCH RoleId for ReadOnly user to Administrator should be rejected.

```
curl -k -i -H "Content-Type: application/json" -X POST https://${bmc}/redfish/v1/AccountService/Accounts/ -d '{"UserName":"testuser","Password":"TestPwd123", "RoleId":"ReadOnly"}'

curl -k -i -H "Content-Type: application/json" -X GET https://${bmc}/redfish/v1/AccountService/Accounts/testuser

curl -k -i -H "Content-Type: application/json" -X POST "https://${bmc}/redfish/v1/SessionService/Sessions" -d '{"UserName":"testuser","Password":"TestPwd123"}'

testuser_token=`curl -k -H "Content-Type: application/json" -X POST https://${bmc}/login -d '{"username": "testuser", "password" :  "TestPwd123"}' | grep token | awk '{print $2;}' | tr -d '"'`
echo ${testuser_token}

curl -k -i -H "Content-Type: application/json" -H "X-Auth-Token: ${testuser_token}" -X PATCH "https://${bmc}/redfish/v1/AccountService/Accounts/testuser" -d '{"RoleId":"Administrator"}'
```

Before the fix, it will be successful. After the fix, it will show
```

{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation.",
        "MessageArgs": [],
        "MessageId": "Base.1.19.InsufficientPrivilege",
        "MessageSeverity": "Critical",
        "Resolution": "Either abandon the operation or change the associated access rights and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.InsufficientPrivilege",
    "message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation."
  }
}
```