### PR TITLE
1110: Change a few message responses as errors

### DIFF
--- a/redfish-core/src/error_messages.cpp
+++ b/redfish-core/src/error_messages.cpp
@@ -428,8 +428,8 @@ void resourceAlreadyExists(crow::Response& res, std::string_view arg1,
                            std::string_view arg2, std::string_view arg3)
 {
     res.result(boost::beast::http::status::bad_request);
-    addMessageToJson(res.jsonValue, resourceAlreadyExists(arg1, arg2, arg3),
-                     arg2);
+    addMessageToErrorJson(res.jsonValue,
+                          resourceAlreadyExists(arg1, arg2, arg3));
 }
 
 /**
@@ -475,8 +475,8 @@ void createFailedMissingReqProperties(crow::Response& res,
 
 /**
  * @internal
- * @brief Formats PropertyValueFormatError message into JSON for the specified
- * property
+ * @brief Formats PropertyValueFormatError message into JSON for the
+ * specified property
  *
  * See header file for more information
  * @endinternal
@@ -494,7 +494,7 @@ void propertyValueFormatError(crow::Response& res, const nlohmann::json& arg1,
                               std::string_view arg2)
 {
     res.result(boost::beast::http::status::bad_request);
-    addMessageToJson(res.jsonValue, propertyValueFormatError(arg1, arg2), arg2);
+    addMessageToErrorJson(res.jsonValue, propertyValueFormatError(arg1, arg2));
 }
 
 /**


### PR DESCRIPTION
Some of messages are not currently reported as errors, although they are the results as Redfish request errors. Those include

- ResourceAlreadyExists
- PropertyValueFormatError

For example, PropertyValueFormatError is currently not treated as an error. It shows like

```

curl -k -X PATCH "${bmc}/redfish/v1/AccountService/Accounts/admin" \
  -H "Content-Type: application/json" \
  -d '{ "Password": "" }'

  "Password@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The value 'null' for the property Password is not a format that the property can accept.",
      "MessageArgs": [
        "null",
        "Password"
      ],
      "MessageId": "Base.1.19.PropertyValueFormatError",
      "MessageSeverity": "Warning",
      "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
    }
  ]
```

After making it as an error, it will be like
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The value 'null' for the property Password is not a format that the property can accept.",
        "MessageArgs": [
          "null",
          "Password"
        ],
        "MessageId": "Base.1.19.PropertyValueFormatError",
        "MessageSeverity": "Warning",
        "Resolution": "Correct the value for the property in the request body and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.PropertyValueFormatError",
    "message": "The value 'null' for the property Password is not a format that the property can accept."
  }
}
```

Tested:
- Check those response messages

Change-Id: I746c55e42e8f0cde205a3800e3da17cd78cf7e34