### PR TITLE
1120 remove success and set no content on account service

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1359,7 +1359,6 @@ inline void afterVerifyUserExists(
             persistent_data::SessionStore::getInstance()
                 .removeSessionsByUsernameExceptSession(params.username,
                                                        params.session);
-            messages::success(asyncResp->res);
         }
     }
 

--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -1359,6 +1359,7 @@ inline void afterVerifyUserExists(
             persistent_data::SessionStore::getInstance()
                 .removeSessionsByUsernameExceptSession(params.username,
                                                        params.session);
+            asyncResp->res.result(boost::beast::http::status::no_content);
         }
     }
 


### PR DESCRIPTION
Currently, PATCH requests updating Password to
/redfish/v1/AccountService/Accounts/{username} will return non-empty
body despite the status code is 204 No Content:

```
curl -X PATCH --user root:0penBmc -H "Content-Type: application/json" --insecure https://${BMC_IP}/redfish/v1/AccountService/Accounts/user_test01 -d '{"Password": "0penBmc"}'
```

```
Sep 29 02:45:09 mtmitchell-dcscm bmcwebd[947]: [http_response.hpp:212] 0x1bce918 Response content provided but code was no-content or not_modified, which aren't allowed to have a body for url
 : "/redfish/v1/AccountService/Accounts/user_test01"
```

This issue has been fixed in 2 upstream commits
- edfd25cd Changing Account Password Returns 204
- adee9f2e account_service: Remove success body on 204 response
