### PR TITLE
1060: Prevent ReadOnly user to escate privilege to Admin

### DIFF
--- a/redfish-core/lib/account_service.hpp
+++ b/redfish-core/lib/account_service.hpp
@@ -2463,6 +2463,17 @@ inline void
         "xyz.openbmc_project.Object.Delete", "Delete");
 }
 
+inline bool ensurePrivilegedProperties(
+    const std::optional<std::string>& newUserName,
+    const std::optional<std::string>& password,
+    const std::optional<bool>& enabled,
+    const std::optional<std::string>& roleId, const std::optional<bool>& locked,
+    const std::optional<std::vector<std::string>>& accountTypes)
+{
+    return !(newUserName || password || enabled || roleId || locked ||
+             accountTypes);
+}
+
 inline void
     handleAccountPatch(App& app, const crow::Request& req,
                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -2503,6 +2514,15 @@ inline void
         {
             if (oem)
             {
+                if (!ensurePrivilegedProperties(newUserName, password, enabled,
+                                                roleId, locked, accountType))
+
+                {
+                    BMCWEB_LOG_WARNING
+                        << "Unauthenticated users are never allowed to PATCH anything other than the \"Oem\" property";
+                    messages::insufficientPrivilege(asyncResp->res);
+                    return;
+                }
                 // allow unauthenticated ACF upload based on panel
                 // function 74 state.
                 triggerUnauthenticatedACFUpload(asyncResp, oem);
@@ -2527,6 +2547,15 @@ inline void
         // 74 is active from panel.
         if (oem && (username == "service"))
         {
+            if (!ensurePrivilegedProperties(newUserName, password, enabled,
+                                            roleId, locked, accountType))
+
+            {
+                BMCWEB_LOG_WARNING
+                    << "Unauthenticated users are never allowed to PATCH anything other than the \"Oem\" property";
+                messages::insufficientPrivilege(asyncResp->res);
+                return;
+            }
             // allow unauthenticated ACF upload based on panel
             // function 74 state.
             triggerUnauthenticatedACFUpload(asyncResp, oem);
@@ -2540,8 +2569,17 @@ inline void
             return;
         }
 
-        // NOTE: password was already obtained from the previous
-        // readJsonPatch().
+        // Read only users should not be allowed to bypass self, except the
+        // password change
+        if (!ensurePrivilegedProperties(newUserName, std::nullopt, enabled,
+                                        roleId, locked, accountType))
+
+        {
+            BMCWEB_LOG_WARNING
+                << "User does not have authority to PATCH anything other than Password";
+            messages::insufficientPrivilege(asyncResp->res);
+            return;
+        }
     }
 
     // For accounts which have a Restricted Role, restrict which


### PR DESCRIPTION
A Redfish user with RoleID as ReadOnly is able to update its own role as Administrator. This causes the privilege escalation to the greater authorities.  It should be rejected as HTTP 403 error.

Tested:
- PATCH RoleId for ReadOnly user to Administrator should be rejected.

```
curl -k -i -H "Content-Type: application/json" -X POST https://${bmc}/redfish/v1/AccountService/Accounts/ -d '{"UserName":"testuser","Password":"TestPwd123", "RoleId":"ReadOnly"}'

curl -k -i -H "Content-Type: application/json" -X GET https://${bmc}/redfish/v1/AccountService/Accounts/testuser

curl -k -i -H "Content-Type: application/json" -X POST "https://${bmc}/redfish/v1/SessionService/Sessions" -d '{"UserName":"testuser","Password":"TestPwd123"}'

testuser_token=`curl -k -H "Content-Type: application/json" -X POST https://${bmc}/login -d '{"username": "testuser", "password" :  "TestPwd123"}' | grep token | awk '{print $2;}' | tr -d '"'`
echo ${testuser_token}

curl -k -i -H "Content-Type: application/json" -H "X-Auth-Token: ${testuser_token}" -X PATCH "https://${bmc}/redfish/v1/AccountService/Accounts/testuser" -d '{"RoleId":"Administrator"}'
```

Before the fix, it will be successful. After the fix, it will show
```

{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation.",
        "MessageArgs": [],
        "MessageId": "Base.1.19.InsufficientPrivilege",
        "MessageSeverity": "Critical",
        "Resolution": "Either abandon the operation or change the associated access rights and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.InsufficientPrivilege",
    "message": "There are insufficient privileges for the account or credentials associated with the current session to perform the requested operation."
  }
}
```