### PR TITLE
hw-isolation: fix redfish validator error for service alert

### DIFF
--- a/redfish-core/lib/oem/ibm/service_alerts.hpp
+++ b/redfish-core/lib/oem/ibm/service_alerts.hpp
@@ -8,6 +8,8 @@
 #include "error_messages.hpp"
 #include "logging.hpp"
 
+#include <asm-generic/errno.h>
+
 #include <boost/system/error_code.hpp>
 #include <sdbusplus/asio/property.hpp>
 
@@ -35,6 +37,13 @@ inline void getServiceAlertsEnabled(
         [asyncResp](const boost::system::error_code& ec, bool enabled) {
             if (ec)
             {
+                if (ec.value() == EBADR)
+                {
+                    BMCWEB_LOG_DEBUG(
+                        "SendServiceAlerts D-Bus object does not exist");
+                    return;
+                }
+
                 BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
                 messages::internalError(asyncResp->res);
                 return;
@@ -66,6 +75,12 @@ inline void setServiceAlertsEnabled(
         [asyncResp](const boost::system::error_code& ec) {
             if (ec)
             {
+                if (ec.value() == EBADR)
+                {
+                    BMCWEB_LOG_DEBUG(
+                        "SendServiceAlerts D-Bus object does not exist");
+                    return;
+                }
                 BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
                 messages::internalError(asyncResp->res);
                 return;

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2818,6 +2818,9 @@ inline void handleComputerSystemGet(
         getLampTestState(asyncResp);
         getSAI(asyncResp, "PartitionSystemAttentionIndicator");
         getSAI(asyncResp, "PlatformSystemAttentionIndicator");
+    }
+    if constexpr (BMCWEB_HW_ISOLATION)
+    {
         getServiceAlertsEnabled(asyncResp);
     }
     if constexpr (BMCWEB_REDFISH_PROVISIONING_FEATURE)
@@ -2949,7 +2952,8 @@ inline void handleComputerSystemPatch(
                 "Oem/IBM/ChapData/ChapName", chapName,                     //
                 "Oem/IBM/ChapData/ChapSecret", chapSecret,                 //
                 "Oem/IBM/PCIeTopologyRefresh", pcieTopologyRefresh,        //
-                "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo       //
+                "Oem/IBM/SavePCIeTopologyInfo", savePCIeTopologyInfo,      //
+                "Oem/IBM/SendServiceAlerts", sendServiceAlerts             //
                 ))
         {
             return;
@@ -3050,6 +3054,10 @@ inline void handleComputerSystemPatch(
         {
             setSAI(asyncResp, "PlatformSystemAttentionIndicator", *platformSAI);
         }
+    }
+
+    if constexpr (BMCWEB_HW_ISOLATION)
+    {
         if (sendServiceAlerts)
         {
             setServiceAlertsEnabled(asyncResp, *sendServiceAlerts);


### PR DESCRIPTION
Fix for redfish validator failure noticed druing bmcweb bump


Change-Id: Ic8748ce62c7728995fd65f85c8680dcfdeabf488