### PR TITLE
http: Allow SNI hostname for IP addresses

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -597,11 +597,6 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             return;
         }
 
-        if (host.host_type() != boost::urls::host_type::name)
-        {
-            // Avoid setting SNI hostname if its IP address
-            return;
-        }
         // Create a null terminated string for SSL
         std::string hostname(host.encoded_host_address());
         if (SSL_set_tlsext_host_name(sslConn->native_handle(),


### PR DESCRIPTION
Remove the host type check that prevented setting SNI hostname when the host is an IP address. This allows TLS connections to IP addresses to include SNI information, which may be required by some servers even when connecting via IP.

The check was preventing SSL_set_tlsext_host_name from being called for IP addresses, but RBMC aggregation expect SNI regardless of whether the connection is made via hostname or IP.

Tested: Verified TLS connections work with both hostnames and IP addresses with SNI enabled.