### PR TITLE
1210: Audit Log: Harden addition of detail data

### DIFF
--- a/http/http_request.hpp
+++ b/http/http_request.hpp
@@ -81,6 +81,17 @@ struct Request : std::enable_shared_from_this<Request>
         ipAddress = boost::asio::ip::address();
         session = nullptr;
         userRole = "";
+        skipAuditDetailFlag = false;
+    }
+
+    void setSkipAuditDetail(bool skip) const
+    {
+        skipAuditDetailFlag = skip;
+    }
+
+    bool skipAuditDetail() const
+    {
+        return skipAuditDetailFlag;
     }
 
     void clearBody()
@@ -171,6 +182,8 @@ struct Request : std::enable_shared_from_this<Request>
     }
 
   private:
+    mutable bool skipAuditDetailFlag = false;
+
     bool setUrlInfo()
     {
         auto result = boost::urls::parse_relative_ref(target());

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2306,7 +2306,8 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
 /*
  * Set ChapData
  */
-inline void setChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+inline void setChapData(const crow::Request& req,
+                        const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
                         std::optional<std::string> chapName,
                         std::optional<std::string> chapSecret)
 {
@@ -2328,6 +2329,7 @@ inline void setChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
 
     if (chapSecret)
     {
+        req.setSkipAuditDetail(true);
         sdbusplus::asio::setProperty(
             *crow::connections::systemBus, "xyz.openbmc_project.PLDM",
             "/xyz/openbmc_project/pldm", "com.ibm.PLDM.ChapData", "ChapSecret",
@@ -3056,7 +3058,7 @@ inline void handleComputerSystemPatch(
 
     if (chapName || chapSecret)
     {
-        setChapData(asyncResp, chapName, chapSecret);
+        setChapData(req, asyncResp, chapName, chapSecret);
     }
 
     if (pcieTopologyRefresh)

--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -1,7 +1,5 @@
 #include "audit_events.hpp"
 
-#include "bmcweb_config.h"
-
 #include "http_request.hpp"
 #include "logging.hpp"
 #include "websocket.hpp"
@@ -119,10 +117,6 @@ void auditSetState(bool enable)
  */
 inline bool checkSkipDetail(const crow::Request& req)
 {
-    const std::string systemPatch =
-        std::format("/redfish/v1/Systems/{}", BMCWEB_REDFISH_SYSTEM_URI_NAME);
-    const std::string systemPatchTrailing = std::format("{}/", systemPatch);
-
     return req.target().starts_with("/redfish/v1/AccountService") ||
            req.target().starts_with("/redfish/v1/CertificateService") ||
            req.target().starts_with("/redfish/v1/EventService/Subscriptions") ||
@@ -131,10 +125,7 @@ inline bool checkSkipDetail(const crow::Request& req)
            req.target().starts_with("/ibm/v1") ||
            ((req.method() == boost::beast::http::verb::post) &&
             (checkPostUser(req) || req.target().contains("Certificates") ||
-             req.target().contains("LogService.CollectDiagnosticData"))) ||
-           ((req.method() == boost::beast::http::verb::patch) &&
-            (req.target() == systemPatch ||
-             req.target() == systemPatchTrailing));
+             req.target().contains("LogService.CollectDiagnosticData")));
 }
 
 /**
@@ -144,6 +135,13 @@ inline bool checkSkipDetail(const crow::Request& req)
  */
 bool wantDetail(const crow::Request& req)
 {
+    // Request is specially marked
+    if (req.skipAuditDetail())
+    {
+        return false;
+    }
+
+    // Check for known Redfish routes to skip detail
     switch (req.method())
     {
         case boost::beast::http::verb::patch:

--- a/src/audit_events.cpp
+++ b/src/audit_events.cpp
@@ -1,5 +1,7 @@
 #include "audit_events.hpp"
 
+#include "bmcweb_config.h"
+
 #include "http_request.hpp"
 #include "logging.hpp"
 #include "websocket.hpp"
@@ -117,12 +119,22 @@ void auditSetState(bool enable)
  */
 inline bool checkSkipDetail(const crow::Request& req)
 {
-    return req.target().starts_with("/redfish/v1/AccountService/Accounts") ||
+    const std::string systemPatch =
+        std::format("/redfish/v1/Systems/{}", BMCWEB_REDFISH_SYSTEM_URI_NAME);
+    const std::string systemPatchTrailing = std::format("{}/", systemPatch);
+
+    return req.target().starts_with("/redfish/v1/AccountService") ||
+           req.target().starts_with("/redfish/v1/CertificateService") ||
+           req.target().starts_with("/redfish/v1/EventService/Subscriptions") ||
+           req.target().starts_with("/redfish/v1/LicenseService/Licenses") ||
            req.target().starts_with("/redfish/v1/UpdateService") ||
            req.target().starts_with("/ibm/v1") ||
            ((req.method() == boost::beast::http::verb::post) &&
-            (checkPostUser(req) ||
-             req.target().contains("LogService.CollectDiagnosticData")));
+            (checkPostUser(req) || req.target().contains("Certificates") ||
+             req.target().contains("LogService.CollectDiagnosticData"))) ||
+           ((req.method() == boost::beast::http::verb::patch) &&
+            (req.target() == systemPatch ||
+             req.target() == systemPatchTrailing));
 }
 
 /**

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -116,6 +116,9 @@ TEST(wantDetail, PositiveTest)
 
     crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
     EXPECT_TRUE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/Systems/system");
+    EXPECT_TRUE(wantDetail(postRequest));
 }
 
 TEST(wantDetail, NegativeTest)
@@ -131,7 +134,9 @@ TEST(wantDetail, NegativeTest)
     EXPECT_FALSE(wantDetail(patchRequest));
 
     patchRequest.target("/redfish/v1/Systems/system");
+    patchRequest.setSkipAuditDetail(true);
     EXPECT_FALSE(wantDetail(patchRequest));
+    patchRequest.setSkipAuditDetail(false); // Reset to default value
 
     patchRequest.target("/redfish/v1/EventService/Subscriptions/1234");
     EXPECT_FALSE(wantDetail(patchRequest));

--- a/test/include/audit_events_test.cpp
+++ b/test/include/audit_events_test.cpp
@@ -130,6 +130,15 @@ TEST(wantDetail, NegativeTest)
     patchRequest.target("/ibm/v1/foo");
     EXPECT_FALSE(wantDetail(patchRequest));
 
+    patchRequest.target("/redfish/v1/Systems/system");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    patchRequest.target("/redfish/v1/EventService/Subscriptions/1234");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
+    patchRequest.target("/redfish/v1/AccountService");
+    EXPECT_FALSE(wantDetail(patchRequest));
+
     crow::Request postRequest{{boost::beast::http::verb::post, url, 11}, ec};
 
     postRequest.target("/redfish/v1/AccountService/Accounts/bar");
@@ -160,6 +169,23 @@ TEST(wantDetail, NegativeTest)
 
     postRequest.target(
         "/redfish/v1/Systems/system/LogServices/Dump/Actions/LogService.CollectDiagnosticData/");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target(
+        "/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target(
+        "/redfish/v1/Managers/bmc/NetworkProtocol/HTTPS/Certificates");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/AccountService/LDAP/Certificates");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/Managers/bmc/Truststore/Certificates");
+    EXPECT_FALSE(wantDetail(postRequest));
+
+    postRequest.target("/redfish/v1/LicenseService/Licenses");
     EXPECT_FALSE(wantDetail(postRequest));
 
     crow::Request getRequest{{boost::beast::http::verb::get, url, 11}, ec};


### PR DESCRIPTION
#### Audit Log: Allow detail data for some system PATCH
```
ChapSecret should not be part of the audit log entry detail data. If the
system PATCH request includes make sure the detail data is not included.
Other PATCH requests for system should include the detail data.

Tested:
 - Confirmed PATCH /redfish/v1/Systems/system with ChapSecret does not
   include detail data in audit log entry.
 - Confirmed PATCH /redfish/v1/Systems/system without ChapSecret does
   include detail data in audit log entry.

Signed-off-by: Janet Adkins <janeta@us.ibm.com>
```