### PR TITLE
Add Redfish API support for SendServiceAlerts setting

### DIFF
--- a/redfish-core/lib/oem/ibm/service_alerts.hpp
+++ b/redfish-core/lib/oem/ibm/service_alerts.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <memory>
+
+namespace redfish
+{
+
+/**
+ * @brief Get service alerts enabled state
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void
+    getServiceAlertsEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG << "Get service alerts enabled state";
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/hardware_isolation/send_service_alerts",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec, bool enabled) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                BMCWEB_LOG_DEBUG
+                    << "SendServiceAlerts D-Bus object does not exist";
+                return;
+            }
+
+            BMCWEB_LOG_ERROR << "DBUS response error: " << ec.message();
+            messages::internalError(asyncResp->res);
+            return;
+        }
+
+        asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+            "#OemComputerSystem.v1_0_0.IBM";
+        asyncResp->res.jsonValue["Oem"]["IBM"]["SendServiceAlerts"] = enabled;
+    });
+}
+
+/**
+ * @brief Set service alerts enabled state
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] enabled     Service alerts enabled state from request.
+ *
+ * @return None.
+ */
+inline void
+    setServiceAlertsEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            bool enabled)
+{
+    BMCWEB_LOG_DEBUG << "Set service alerts enabled state to: " << enabled;
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/hardware_isolation/send_service_alerts",
+        "xyz.openbmc_project.Object.Enable", "Enabled", enabled,
+        [asyncResp](const boost::system::error_code& ec) {
+        if (ec)
+        {
+            if (ec.value() == EBADR)
+            {
+                BMCWEB_LOG_ERROR
+                    << "SendServiceAlerts D-Bus object does not exist";
+                messages::propertyUnknown(asyncResp->res, "SendServiceAlerts");
+                return;
+            }
+            BMCWEB_LOG_ERROR << "DBUS response error: " << ec.message();
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        BMCWEB_LOG_DEBUG << "Service alerts setting updated successfully";
+    });
+}
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -27,6 +27,9 @@
 #include "oem/ibm/system_attention_indicator.hpp"
 #endif
 #include "oem/ibm/pcie_topology_refresh.hpp"
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+#include "oem/ibm/service_alerts.hpp"
+#endif
 
 #include <app.hpp>
 #include <boost/asio/error.hpp>
@@ -2877,6 +2880,9 @@ inline void requestRoutesSystems(App& app)
         getSAI(asyncResp, "PartitionSystemAttentionIndicator");
         getSAI(asyncResp, "PlatformSystemAttentionIndicator");
 #endif
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+        getServiceAlertsEnabled(asyncResp);
+#endif
 #ifdef BMCWEB_ENABLE_REDFISH_PROVISIONING_FEATURE
         getProvisioningStatus(asyncResp);
 #endif
@@ -3034,6 +3040,7 @@ inline void requestRoutesSystems(App& app)
                 std::optional<bool> savePCIeTopologyInfo;
                 std::optional<std::string> chapName;
                 std::optional<std::string> chapSecret;
+                std::optional<bool> sendServiceAlerts;
                 if (!json_util::readJson(
                         *ibmOem, asyncResp->res, "LampTest", lampTest,
                         "PartitionSystemAttentionIndicator", partitionSAI,
@@ -3041,7 +3048,7 @@ inline void requestRoutesSystems(App& app)
                         "PCIeTopologyRefresh", pcieTopologyRefresh,
                         "SavePCIeTopologyInfo", savePCIeTopologyInfo,
                         "ChapData/ChapName", chapName, "ChapData/ChapSecret",
-                        chapSecret))
+                        chapSecret, "SendServiceAlerts", sendServiceAlerts))
                 {
                     return;
                 }
@@ -3059,19 +3066,33 @@ inline void requestRoutesSystems(App& app)
                     setSAI(asyncResp, "PlatformSystemAttentionIndicator",
                            *platformSAI);
                 }
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+                if (sendServiceAlerts)
+                {
+                    setServiceAlertsEnabled(asyncResp, *sendServiceAlerts);
+                }
+#endif
 #else
                 std::optional<bool> pcieTopologyRefresh;
                 std::optional<bool> savePCIeTopologyInfo;
                 std::optional<std::string> chapName;
                 std::optional<std::string> chapSecret;
+                std::optional<bool> sendServiceAlerts;
                 if (!json_util::readJson(
                         *ibmOem, asyncResp->res, "PCIeTopologyRefresh",
                         pcieTopologyRefresh, "SavePCIeTopologyInfo",
                         savePCIeTopologyInfo, "ChapData/ChapName", chapName,
-                        "ChapData/ChapSecret", chapSecret))
+                        "ChapData/ChapSecret", chapSecret, "SendServiceAlerts",
+                        sendServiceAlerts))
                 {
                     return;
                 }
+#ifdef BMCWEB_ENABLE_HW_ISOLATION
+                if (sendServiceAlerts)
+                {
+                    setServiceAlertsEnabled(asyncResp, *sendServiceAlerts);
+                }
+#endif
 #endif
                 if (pcieTopologyRefresh)
                 {

--- a/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
+++ b/static/redfish/v1/JsonSchemas/OemComputerSystem/OemComputerSystem.json
@@ -201,6 +201,15 @@
                     "$ref": "#/definitions/ChapData",
                     "description": "ChapData.",
                     "longDescription": "This property shall describe ChapData."
+                },
+                "SendServiceAlerts": {
+                    "description": "An indication of whether service alerts are enabled.",
+                    "longDescription": "The value of this property shall indicate if service alerts are enabled.",
+                    "readonly": false,
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
                 }
             },
             "type": "object"

--- a/static/redfish/v1/schema/OemComputerSystem_v1.xml
+++ b/static/redfish/v1/schema/OemComputerSystem_v1.xml
@@ -100,6 +100,11 @@
                   <Annotation Term="OData.Description" String="An indication of PEL topology information is saves."/>
                   <Annotation Term="OData.LongDescription" String="This property when set to 'true' saves the topology information. The information is saved in the form of a PEL(Error Log)."/>
                 </Property>
+                <Property Name="SendServiceAlerts" Type="Edm.Boolean">
+                  <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+                  <Annotation Term="OData.Description" String="An indication of whether service alerts are enabled."/>
+                  <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if service alerts are enabled."/>
+                </Property>
             </ComplexType>
         </Schema>
 


### PR DESCRIPTION
This commit adds support for controlling the hardware isolation service alerts setting through the Redfish API under the IBM OEM extension.

Changes:
- Created service_alerts.hpp with GET/SET functions for the SendServiceAlerts property
- Modified systems.hpp to expose SendServiceAlerts in the IBM OEM section of ComputerSystem resource
- Added error handling for missing D-Bus object (EBADR) to prevent redfish validator GET failure 500

The SendServiceAlerts property allows users to enable or disable service alerts for hardware isolation events via Redfish API:
- GET /redfish/v1/Systems/system returns current state
- PATCH /redfish/v1/Systems/system with Oem.IBM.SendServiceAlerts updates the setting

The implementation integrates with the existing D-Bus setting at /xyz/openbmc_project/hardware_isolation/send_service_alerts which is monitored by the faultlog service.

Tested:
- GET request returns current SendServiceAlerts state
- PATCH request successfully updates the D-Bus property
- Setting persists across BMC reboots via phosphor-settings-manager
- Redfish validator passes without 500 errors

Change-Id: Ib6a488f1697cbdc28e3361f92ead70f38d61ba41