### PR TITLE
Add Redfish API support for SendServiceAlerts setting

### DIFF
--- a/redfish-core/lib/oem/ibm/service_alerts.hpp
+++ b/redfish-core/lib/oem/ibm/service_alerts.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_singleton.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "logging.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <sdbusplus/asio/property.hpp>
+
+#include <memory>
+
+namespace redfish
+{
+
+/**
+ * @brief Get service alerts enabled state
+ *
+ * @param[in] asyncResp     Shared pointer for generating response message.
+ *
+ * @return None.
+ */
+inline void
+    getServiceAlertsEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
+{
+    BMCWEB_LOG_DEBUG("Get service alerts enabled state");
+
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/hardware_isolation/send_service_alerts",
+        "xyz.openbmc_project.Object.Enable", "Enabled",
+        [asyncResp](const boost::system::error_code& ec, bool enabled) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    BMCWEB_LOG_DEBUG(
+                        "SendServiceAlerts D-Bus object does not exist");
+                    return;
+                }
+
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+
+            asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
+                "#IBMComputerSystem.v1_0_0.IBM";
+            asyncResp->res.jsonValue["Oem"]["IBM"]["SendServiceAlerts"] =
+                enabled;
+        });
+}
+
+/**
+ * @brief Set service alerts enabled state
+ *
+ * @param[in] asyncResp   Shared pointer for generating response message.
+ * @param[in] enabled     Service alerts enabled state from request.
+ *
+ * @return None.
+ */
+inline void setServiceAlertsEnabled(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool enabled)
+{
+    BMCWEB_LOG_DEBUG("Set service alerts enabled state to: {}", enabled);
+    sdbusplus::asio::setProperty(
+        *crow::connections::systemBus, "xyz.openbmc_project.Settings",
+        "/xyz/openbmc_project/hardware_isolation/send_service_alerts",
+        "xyz.openbmc_project.Object.Enable", "Enabled", enabled,
+        [asyncResp](const boost::system::error_code& ec) {
+            if (ec)
+            {
+                if (ec.value() == EBADR)
+                {
+                    BMCWEB_LOG_ERROR(
+                        "SendServiceAlerts D-Bus object does not exist");
+                    messages::propertyUnknown(asyncResp->res,
+                                              "SendServiceAlerts");
+                    return;
+                }
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec.message());
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            BMCWEB_LOG_DEBUG("Service alerts setting updated successfully");
+        });
+}
+} // namespace redfish

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -29,6 +29,7 @@
 #include "led.hpp"
 #include "oem/ibm/lamp_test.hpp"
 #include "oem/ibm/pcie_topology_refresh.hpp"
+#include "oem/ibm/service_alerts.hpp"
 #include "oem/ibm/system_attention_indicator.hpp"
 #include "query.hpp"
 #include "redfish_util.hpp"
@@ -2880,6 +2881,10 @@ inline void
         getSAI(asyncResp, "PartitionSystemAttentionIndicator");
         getSAI(asyncResp, "PlatformSystemAttentionIndicator");
     }
+    if constexpr (BMCWEB_HW_ISOLATION)
+    {
+        getServiceAlertsEnabled(asyncResp);
+    }
     if constexpr (BMCWEB_REDFISH_PROVISIONING_FEATURE)
     {
         getProvisioningStatus(asyncResp);
@@ -3058,6 +3063,7 @@ inline void handleComputerSystemPatch(
                 std::optional<bool> lampTest;
                 std::optional<bool> partitionSAI;
                 std::optional<bool> platformSAI;
+                std::optional<bool> sendServiceAlerts;
                 if (!json_util::readJson(
                         *ibmOem, asyncResp->res, "LampTest", lampTest,
                         "PartitionSystemAttentionIndicator", partitionSAI,
@@ -3065,7 +3071,7 @@ inline void handleComputerSystemPatch(
                         "PCIeTopologyRefresh", pcieTopologyRefresh,
                         "SavePCIeTopologyInfo", savePCIeTopologyInfo,
                         "ChapData/ChapName", chapName, "ChapData/ChapSecret",
-                        chapSecret))
+                        chapSecret, "SendServiceAlerts", sendServiceAlerts))
                 {
                     return;
                 }
@@ -3083,16 +3089,32 @@ inline void handleComputerSystemPatch(
                     setSAI(asyncResp, "PlatformSystemAttentionIndicator",
                            *platformSAI);
                 }
+                if constexpr (BMCWEB_HW_ISOLATION)
+                {
+                    if (sendServiceAlerts)
+                    {
+                        setServiceAlertsEnabled(asyncResp, *sendServiceAlerts);
+                    }
+                }
             }
             else
             {
+                std::optional<bool> sendServiceAlerts;
                 if (!json_util::readJson(
                         *ibmOem, asyncResp->res, "PCIeTopologyRefresh",
                         pcieTopologyRefresh, "SavePCIeTopologyInfo",
                         savePCIeTopologyInfo, "ChapData/ChapName", chapName,
-                        "ChapData/ChapSecret", chapSecret))
+                        "ChapData/ChapSecret", chapSecret, "SendServiceAlerts",
+                        sendServiceAlerts))
                 {
                     return;
+                }
+                if constexpr (BMCWEB_HW_ISOLATION)
+                {
+                    if (sendServiceAlerts)
+                    {
+                        setServiceAlertsEnabled(asyncResp, *sendServiceAlerts);
+                    }
                 }
             }
             if (pcieTopologyRefresh)

--- a/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMComputerSystem_v1.xml
@@ -58,6 +58,11 @@
           <Annotation Term="OData.Description" String="An indication of whether safe mode is active."/>
           <Annotation Term="OData.LongDescription" String="The value of this property shall indicate if safe mode is active."/>
         </Property>
+        <Property Name="SendServiceAlerts" Type="Edm.Boolean">
+          <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
+          <Annotation Term="OData.Description" String="An indicator allowing an operator to enable or disable service alerts."/>
+          <Annotation Term="OData.LongDescription" String="This property shall contain the state of service alerts function for this resource."/>
+        </Property>
       </ComplexType>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMComputerSystem.v1_0_0">

--- a/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
+++ b/redfish-core/schema/oem/ibm/json-schema/IBMComputerSystem.v1_0_0.json
@@ -98,6 +98,12 @@
                     "longDescription": "The value of this property shall indicate if safe mode is active.",
                     "readonly": true,
                     "type": ["boolean", "null"]
+                },
+                "SendServiceAlerts": {
+                    "description": "An indicator to enable or disable sending service alerts for hardware isolation events.",
+                    "longDescription": "This property shall indicate whether service alerts should be sent when hardware isolation events occur. When set to 'true', service alerts will be sent. When set to 'false', service alerts will be suppressed.",
+                    "readonly": false,
+                    "type": ["boolean", "null"]
                 }
             },
             "type": "object"


### PR DESCRIPTION
This commit adds support for controlling the hardware isolation service alerts setting through the Redfish API under the IBM OEM extension.

Changes:
- Created service_alerts.hpp with GET/SET functions for the SendServiceAlerts property
- Modified systems.hpp to expose SendServiceAlerts in the IBM OEM section of ComputerSystem resource
- Updated IBMComputerSystem.v1_0_0.json schema to document the new SendServiceAlerts property
- Added error handling for missing D-Bus object (EBADR) to prevent redfish validator GET failure 500

The SendServiceAlerts property allows users to enable or disable service alerts for hardware isolation events via Redfish API:
- GET /redfish/v1/Systems/system returns current state
- PATCH /redfish/v1/Systems/system with Oem.IBM.SendServiceAlerts updates the setting

The implementation integrates with the existing D-Bus setting at /xyz/openbmc_project/hardware_isolation/send_service_alerts which is monitored by the faultlog service.

Tested:
- GET request returns current SendServiceAlerts state
- PATCH request successfully updates the D-Bus property
- Setting persists across BMC reboots via phosphor-settings-manager
- Redfish validator passes without 500 errors

Change-Id: I2e437fb3673d4019bdf89574f5ea3714df0ff33e