### PR TITLE
1110: Fix coredump in http_client during rapid connection destruction

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -681,7 +681,19 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
     // Otherwise closes the connection if it is not a keep-alive
     void sendNext(bool keepAlive, uint32_t connId)
     {
+        if (connId >= connections.size())
+        {
+            BMCWEB_LOG_ERROR("Invalid connId: {} (size: {})", connId,
+                             connections.size());
+            return;
+        }
+
         auto conn = connections[connId];
+        if (!conn)
+        {
+            BMCWEB_LOG_ERROR("Connection at index {} is null", connId);
+            return;
+        }
 
         // Allow the connection's handler to be deleted
         // This is needed because of Redfish Aggregation passing an
@@ -798,10 +810,6 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                               const std::function<void(Response&)>& resHandler,
                               bool keepAlive, uint32_t connId, Response& res)
     {
-        // Allow provided callback to perform additional processing of the
-        // request
-        resHandler(res);
-
         // If requests remain in the queue then we want to reuse this
         // connection to send the next request
         std::shared_ptr<ConnectionPool> self = weakSelf.lock();
@@ -811,6 +819,10 @@ class ConnectionPool : public std::enable_shared_from_this<ConnectionPool>
                                 logPtr(self.get()));
             return;
         }
+
+        // Allow provided callback to perform additional processing of the
+        // request
+        resHandler(res);
 
         self->sendNext(keepAlive, connId);
     }


### PR DESCRIPTION
Issue:
BMCWeb crashes with segmentation fault when HTTP client connections are rapidly created and destroyed while async operations are pending. This occurs during event subscription deletion, BMCWeb shutdown, or network timeout scenarios where ConnectionPool is destroyed while callbacks are still executing.

Root Cause:
Race condition between async callback execution and ConnectionPool destruction leads to three failure modes:
1. Out-of-bounds vector access in sendNext() when connId is invalid
2. Null pointer dereference when connection pointer is null
3. Use-after-free when callback executes after pool destruction

The issue manifests as:
- Segmentation fault in sendNext()
- Crash in afterSendData() when accessing destroyed pool
- Invalid memory access during callback execution

Key Fixes:
1. Bounds Checking
   - Validate connId < connections.size() before vector access
   - Prevents segmentation fault from out-of-bounds access
   - Returns early with error log if connId invalid

2. Null Pointer Validation
   - Check if connection pointer is null before dereferencing
   - Provides graceful error handling instead of crash
   - Logs error and returns safely

3. Reordered afterSendData()
   - Check ConnectionPool validity BEFORE calling user callback
   - Prevents callback execution if pool has been destroyed
   - Ensures safe early return if pool no longer exists

Testing:
Reproduced coredump by simulating aggressive client behavior:
- Client rapidly creates HTTP connections to BMCWeb
- Client sends POST requests to create event subscriptions
- Client abruptly closes connections during SSL handshake
- Client destroys sessions while async operations are pending
- This triggers race condition where callbacks execute after ConnectionPool destruction

Example Python code that reproduces the issue:
```
  for i in range(100):
      session = requests.Session()
      session.post('https://bmc/redfish/v1/EventService/Subscriptions',
                   json={'Destination': 'http://192.0.2.1:8080/events'})
      time.sleep(0.01)  # Brief delay
      session.close()   # Abrupt destruction while request pending
      del session
```

Before fix:
- Segmentation fault in sendNext()
- BMCWeb process crashes
- Coredump generated

After fix:
- No coredumps detected
- BMCWeb process remains stable
- Graceful error handling with log messages: "Invalid connId: X (size: Y)" "Connection at index X is null" "Failed to capture connection"

Expected logs during aggressive client testing (normal behavior):
- SSL handshake failures (client abruptly disconnects)
- Authentication failures (connections close during auth)
- No segmentation faults or process crashes

Verification:
  coredumpctl list bmcweb        # No new coredumps
  systemctl status bmcweb        # Process still running
  dmesg | grep segfault          # No segmentation faults