### PR TITLE
Revert dump on timeout and bump to 100 secs

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -557,7 +557,7 @@ inline void afterUpdateErrorMatcher(
 inline void monitorForSoftwareAvailable(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const crow::Request& req, const std::string& url,
-    int timeoutTimeSeconds = 50)
+    int timeoutTimeSeconds = 100)
 {
     // Only allow one FW update at a time
     if (fwUpdateInProgress)

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -430,31 +430,6 @@ inline void softwareInterfaceAdded(
     }
 }
 
-// TODO(Gunnar): Remove this 6/15/26
-inline void createBMCDump()
-{
-    std::vector<std::pair<std::string, std::variant<std::string, uint64_t>>>
-        createDumpParamVec;
-
-    createDumpParamVec.emplace_back(
-        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorId",
-        "bmcweb-internal");
-    createDumpParamVec.emplace_back(
-        "xyz.openbmc_project.Dump.Create.CreateParameters.OriginatorType",
-        "xyz.openbmc_project.Common.OriginatedBy.OriginatorTypes.Internal");
-
-    crow::connections::systemBus->async_method_call(
-        [](const boost::system::error_code& ec) {
-            if (ec)
-            {
-                BMCWEB_LOG_ERROR("Failed to do a dump:{}", ec.value());
-                return;
-            }
-        },
-        "xyz.openbmc_project.Dump.Manager", "/xyz/openbmc_project/dump/bmc",
-        "xyz.openbmc_project.Dump.Create", "CreateDump", createDumpParamVec);
-}
-
 inline void afterAvailbleTimerAsyncWait(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const boost::system::error_code& ec)
@@ -467,9 +442,6 @@ inline void afterAvailbleTimerAsyncWait(
     }
     BMCWEB_LOG_ERROR("Timed out waiting for firmware object being created");
     BMCWEB_LOG_ERROR("FW image may has already been uploaded to server");
-    // TODO(Gunnar): Remove this 6/15/26, this is here to try to figure what is
-    // slowing down the system so much.
-    createBMCDump();
     if (ec)
     {
         BMCWEB_LOG_ERROR("Async_wait failed{}", ec);


### PR DESCRIPTION
1) Revert https://github.com/ibm-openbmc/bmcweb/pull/1450 as planned
2) Bump the timeout to 100 seconds for 1120 only since we have this hit the timeout twice. Haven't seen since I added that dump so :/ For 1120 going to rely on better hardware so 1120 only and not upstream. 