### PR TITLE
1110: Bump the timeout to 100 seconds

### DIFF
--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -515,7 +515,7 @@ inline void
 static void monitorForSoftwareAvailable(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const crow::Request& req, const std::string& url,
-    int timeoutTimeSeconds = 50)
+    int timeoutTimeSeconds = 100)
 {
     // Only allow one FW update at a time
     if (fwUpdateInProgress)


### PR DESCRIPTION
This is a retrofit of https://github.com/ibm-openbmc/bmcweb/pull/1478 to 1110.

Seen twice where we have hit the 50 sec timeout. No idea why and after I added the dump, haven't seen it at all.

All places use the default, so bump the default to 100. This is only going to be a 1120 change. For 1210, will not do anything unless we hit this. For 1210 will have better hardware.

