### PR TITLE
RBMC: Implement ActiveRedundancySet for active manager

### DIFF
--- a/docs/Redfish.md
+++ b/docs/Redfish.md
@@ -604,6 +604,7 @@ Fields common to all schemas
 - Redundancy[]/MinNumNeeded
 - Redundancy[]/Mode
 - Redundancy[]/RedundancySet[]
+- Redundancy[]/ActiveRedundancySet[]
 - SerialNumber
 - ServiceEntryPointUUID
 - ServiceIdentification

--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -79,12 +79,14 @@ inline void getRedundantData(
     const size_t* redundancyMinimum = nullptr;
     const size_t* redundancyMaximum = nullptr;
     const size_t* functionalMinimum = nullptr;
+    const std::string* role = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), propertiesList, "FailoversAllowed",
         failoversAllowed, "RedundancyEnabled", redundancyEnabled,
         "RedundancyMinimum", redundancyMinimum, "RedundancyMaximum",
-        redundancyMaximum, "FunctionalMinimum", functionalMinimum);
+        redundancyMaximum, "FunctionalMinimum", functionalMinimum, "Role",
+        role);
 
     if (!success)
     {
@@ -145,6 +147,23 @@ inline void getRedundantData(
     if (functionalMinimum != nullptr)
     {
         redundantObject["MinNumNeeded"] = *functionalMinimum;
+    }
+
+    if (role != nullptr)
+    {
+        BMCWEB_LOG_DEBUG("Initializing ActiveRedundancySet array");
+        nlohmann::json::array_t activeSet;
+
+        if (*role == "xyz.openbmc_project.State.BMC.Redundancy.Role.Active")
+        {
+            nlohmann::json::object_t activeItem;
+            activeItem["@odata.id"] =
+                boost::urls::format("/redfish/v1/Managers/{}", managerId);
+            activeSet.emplace_back(std::move(activeItem));
+        }
+
+        redundantObject["ActiveRedundancySet@odata.count"] = activeSet.size();
+        redundantObject["ActiveRedundancySet"] = std::move(activeSet);
     }
 
     redundancy->emplace_back(std::move(redundantObject));


### PR DESCRIPTION
BMC has D-Bus interface `xyz.open_bmc.State.BMC.Redundancy` has the property `Role`[1] which defines the active/passive RBMC

This commit implements `ActiveRedundancySet`[2] for the active manager for now.

Tested:
- Redfish service validator passes
- Verified response on active BMC
```
curl -H "X-Auth-Token: $token" https://${bmc}/redfish/v1/Managers/bmc
```
```
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_15_0.Manager",

  ...

  "Redundancy": [
    {
      "@odata.id": "/redfish/v1/Managers/bmc#/Redundancy/0",
      "ActiveRedundancySet": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc"
        }
      ],
      "ActiveRedundancySet@odata.count": 1,
      "MemberId": "0",
      "MinNumNeeded": 1,
      "MinNumNeededForFaultTolerance": 2,
      "Mode": "NotRedundant",
      "Name": "Manager Redundancy",
      "RedundancySet": [
        {
          "@odata.id": "/redfish/v1/Managers/bmc"
        }
      ],
      "RedundancySet@odata.count": 1,
      "Status": {
        "Health": "OK",
        "State": "Disabled"
      }
    }
  ],
  "Redundancy@odata.count": 1,

  ...

}
```

[1]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/928df5e0ef56613520ad17e16924b524b69408cb/yaml/xyz/openbmc_project/State/BMC/Redundancy.interface.yaml#L109
[2]: https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2026.1.pdf