### PR TITLE
1120: Add defensive callback invocation

### DIFF
--- a/http/http_client.hpp
+++ b/http/http_client.hpp
@@ -439,7 +439,10 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
         // Copy the response into a Response object so that it can be
         // processed by the callback function.
         res.response = parser->release();
-        callback(parser->keep_alive(), connId, res);
+        if (callback)
+        {
+            callback(parser->keep_alive(), connId, res);
+        }
         res.clear();
     }
 
@@ -487,7 +490,10 @@ class ConnectionInfo : public std::enable_shared_from_this<ConnectionInfo>
             // We want to return a 502 to indicate there was an error with
             // the external server
             res.result(boost::beast::http::status::bad_gateway);
-            callback(false, connId, res);
+            if (callback)
+            {
+                callback(false, connId, res);
+            }
             res.clear();
 
             // Reset the retrycount to zero so that client can try


### PR DESCRIPTION
We have experienced a `std::bad_function_call` exception [1]. The journal entries are showing
```
Jun 17 15:27:21.985663 bmcwebd[1995]: [http_client.hpp:391] recvMessage() failed: asio.ssl error from https://10.5.10.140:17443/redfish/events
Jun 17 15:27:22.043798 bmcwebd[1995]: [http_client.hpp:391] recvMessage() failed: stale parser from https://10.5.10.140:17443/redfish/events
Jun 17 15:27:22.085644 bmcwebd[1995]: terminate called after throwing an instance of 'std::bad_function_call'
Jun 17 15:27:22.086908 bmcwebd[1995]:   what():  bad_function_call
Jun 17 15:27:22.163520 systemd-coredump[4621]: Process 1995 (bmcwebd) of user 0 terminated abnormally with signal 6/ABRT
```

The matching line is
```
void recvMessage(const std::shared_ptr<ConnectionInfo>& /*self*/,
                 const boost::system::error_code& ec,
                 std::size_t bytesTransferred)
{
    ...
    callback(parser->keep_alive(), connId, res);
    ...
}
```

This would imply that the callback function pointer became null when it is invoked.

```
void sendNext(bool keepAlive, uint32_t connId)
{
    ...
    conn->callback = nullptr;  // ← Clears the callback
    ...
}
```

This may be happening due to the race condition between multiple async operations, where the async call is waiting to be invoked but sendNext is executed.

This commit is to make the defensive checking of `callback` function pointer beforce invoking like

```
   if (callback) {
      callback(parser->keep_alive(), connId, res);
   }
```

Change-Id: Ic23e17ea486433e3bb7493e8e3c1e56b1798c8e9