### PR TITLE
RBMC: Implement Manager.ForceFailover

### DIFF
--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright OpenBMC Authors
 #pragma once
 
+#include "app.hpp"
 #include "async_resp.hpp"
 #include "dbus_singleton.hpp"
 #include "dbus_utility.hpp"
@@ -9,6 +10,7 @@
 #include "generated/enums/redundancy.hpp"
 #include "generated/enums/resource.hpp"
 #include "logging.hpp"
+#include "query.hpp"
 #include "utils/dbus_utils.hpp"
 
 #include <asm-generic/errno.h>
@@ -229,6 +231,79 @@ inline void getManagerRedundancy(
     dbus::utility::getSubTree(
         "/xyz/openbmc_project/state", 0, interfaces,
         std::bind_front(handleRedundancySubTree, asyncResp, managerId));
+}
+
+inline void handleManagerForceFailover(
+    crow::App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& managerId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if (managerId != BMCWEB_REDFISH_MANAGER_URI_NAME)
+    {
+        messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+        return;
+    }
+
+    BMCWEB_LOG_DEBUG("Post Force Failover");
+
+    std::optional<std::string> newManager;
+
+    if (!json_util::readJsonAction(req, asyncResp->res, "NewManager/@odata.id",
+                                   newManager))
+    {
+        return;
+    }
+
+    boost::system::result<boost::urls::url> parsedUrl =
+        boost::urls::parse_relative_ref(*newManager);
+    if (crow::utility::readUrlSegments(*parsedUrl, "redfish", "v1", "Managers",
+                                       BMCWEB_REDFISH_MANAGER_URI_NAME))
+    {
+        BMCWEB_LOG_WARNING(
+            "Invalid property value for NewManager/@odata.id: {}", *newManager);
+        messages::actionParameterNotSupported(asyncResp->res, *newManager,
+                                              "ForceFailover");
+        return;
+    }
+
+    std::map<std::string, std::variant<bool>> options;
+    options.emplace("xyz.openbmc_project.Control.Failover.Options.Force", true);
+
+    constexpr const char* requester =
+        "xyz.openbmc_project.Control.Failover.Requester.Redfish";
+    constexpr const char* service = "xyz.openbmc_project.State.BMC.Redundancy";
+    constexpr const char* objectPath = "/xyz/openbmc_project/state/bmc0";
+    constexpr const char* interfaceName =
+        "xyz.openbmc_project.Control.Failover";
+
+    crow::connections::systemBus->async_method_call(
+        [asyncResp](const boost::system::error_code& ec,
+                    const sdbusplus::message_t& msg) {
+            if (ec)
+            {
+                const sd_bus_error* dbusError = msg.get_error();
+                if (dbusError != nullptr)
+                {
+                    if (std::string_view(
+                            "xyz.openbmc_project.Common.Error.Unavailable") ==
+                        dbusError->name)
+                    {
+                        messages::resourceInUse(asyncResp->res);
+                        return;
+                    }
+                }
+                BMCWEB_LOG_ERROR("DBUS response error: {}", ec);
+                messages::internalError(asyncResp->res);
+                return;
+            }
+            messages::success(asyncResp->res);
+        },
+        service, objectPath, interfaceName, "StartFailover", requester,
+        options);
 }
 
 } // namespace redfish

--- a/redfish-core/lib/managers.hpp
+++ b/redfish-core/lib/managers.hpp
@@ -861,6 +861,13 @@ inline void handleManagerGet(
     std::pair<std::string, std::string> redfishDateTimeOffset =
         redfish::time_utils::getDateTimeOffsetNow();
 
+    nlohmann::json& forceFailover =
+        asyncResp->res.jsonValue["Actions"]["#Manager.ForceFailover"];
+
+    forceFailover["target"] = boost::urls::format(
+        "/redfish/v1/Managers/{}/Actions/Manager.ForceFailover",
+        BMCWEB_REDFISH_MANAGER_URI_NAME);
+
     asyncResp->res.jsonValue["DateTime"] = redfishDateTimeOffset.first;
     asyncResp->res.jsonValue["DateTimeLocalOffset"] =
         redfishDateTimeOffset.second;
@@ -1075,6 +1082,12 @@ inline void requestRoutesManagerResetAction(App& app)
         .privileges(redfish::privileges::getActionInfo)
         .methods(boost::beast::http::verb::get)(
             std::bind_front(handleManagerResetActionInfo, std::ref(app)));
+
+    BMCWEB_ROUTE(app,
+                 "/redfish/v1/Managers/<str>/Actions/Manager.ForceFailover/")
+        .privileges(redfish::privileges::postManager)
+        .methods(boost::beast::http::verb::post)(
+            std::bind_front(handleManagerForceFailover, std::ref(app)));
 }
 
 } // namespace redfish


### PR DESCRIPTION
RBMC: Implement Manager.ForceFailover
Added action target to GET Managers/{manager}[1]
Implemented route to allow POST ForceFailover action for Manager[2] to allow
failover to passive BMC
For now failovers work on the passive BMC. Active BMC will return
Unavailable

Tested:
- Redfish service validator passes
- GET request to /redfish/v1/Managers/{manager_id} shows
```
{
  "@odata.id": "/redfish/v1/Managers/bmc",
  "@odata.type": "#Manager.v1_15_0.Manager",
  "Actions": {
    "#Manager.ForceFailover": {
      "target": "/redfish/v1/Managers/bmc/Actions/Manager.ForceFailover"
    },
    "#Manager.Reset": {
      "@Redfish.ActionInfo": "/redfish/v1/Managers/bmc/ResetActionInfo",
      "target": "/redfish/v1/Managers/bmc/Actions/Manager.Reset"
    },
    "#Manager.ResetToDefaults": {
      "ResetType@Redfish.AllowableValues": [
        "ResetAll"
      ],
      "target": "/redfish/v1/Managers/bmc/Actions/Manager.ResetToDefaults"
    }
  },
  ...
}

```
- Request for Failover works on passive BMC when RedundancyEnabled and
  FailoversAllowed
```
curl -k -v -X POST https://${bmc}/redfish/v1/Managers/bmc/Actions/Manager.ForceFailover -d '{ "NewManager": { "@odata.id": "/redfish/v1/Managers/bmc" } }' -H "Content-Type: application/json"
```
- Returns on success
```
{
  "@Message.ExtendedInfo": [
    {
      "@odata.type": "#Message.v1_1_1.Message",
      "Message": "The request completed successfully.",
      "MessageArgs": [],
      "MessageId": "Base.1.19.Success",
      "MessageSeverity": "OK",
      "Resolution": "None."
    }
  ]
}
```
- With xyz.openbmc_project.Common.Error.Unavailable
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The change to the requested resource failed because the resource is in use or in transition.",
        "MessageArgs": [],
        "MessageId": "Base.1.19.ResourceInUse",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the condition and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.ResourceInUse",
    "message": "The change to the requested resource failed because the resource is in use or in transition."
  }
}
```
- Otherwise on other errors
```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The request failed due to an internal service error.  The service is still operational.",
        "MessageArgs": [],
        "MessageId": "Base.1.19.InternalError",
        "MessageSeverity": "Critical",
        "Resolution": "Resubmit the request.  If the problem persists, consider resetting the service."
      }
    ],
    "code": "Base.1.19.InternalError",
    "message": "The request failed due to an internal service error.  The service is still operational."
  }
```

[1]: https://redfish.dmtf.org/schemas/v1/Manager.v1_25_0.json
[2]: https://github.com/openbmc/phosphor-dbus-interfaces/blob/master/yaml/xyz/openbmc_project/Control/Failover.interface.yaml