### PR TITLE
1210: Fix AdditionalData field after its type change.

### DIFF
--- a/include/dbus_utility.hpp
+++ b/include/dbus_utility.hpp
@@ -15,6 +15,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <span>
 #include <string>
@@ -58,7 +59,8 @@ using DbusVariantType = std::variant<
       std::string, std::string, uint64_t>>,
     std::vector<std::pair<sdbusplus::message::object_path, std::string>>,
     std::vector<std::tuple<std::string, uint64_t, std::string, double>>,
-    std::vector<std::tuple<std::string, std::string, uint64_t, std::string>>
+    std::vector<std::tuple<std::string, std::string, uint64_t, std::string>>,
+    std::map<std::string, std::string>
  >;
 
 // clang-format on

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -62,6 +62,7 @@
 #include <format>
 #include <fstream>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -150,7 +151,7 @@ inline bool doUpdateErrorLoggingEntry(
     const std::shared_ptr<task::TaskData>& taskData, const std::string& index,
     const dbus::utility::DBusPropertiesMap& properties)
 {
-    using AdditionalDataType = std::vector<std::string>;
+    using AdditionalDataType = std::map<std::string, std::string>;
 
     const AdditionalDataType* addData = nullptr;
     const std::string* message = nullptr;
@@ -192,10 +193,9 @@ inline bool doUpdateErrorLoggingEntry(
     }
 
     std::string addDataStr;
-    for (const auto& data : *addData)
+    for (const auto& [key, value] : *addData)
     {
-        addDataStr.append(data);
-        addDataStr.append(" ");
+        addDataStr.append(std::format("{}={} ", key, value));
     }
 
     if (!message->empty() && !addDataStr.empty() && !eventId->empty())


### PR DESCRIPTION
Code update fails on reading and parsing of PEL record and the journal shows
```
Fri Jun 26 11:27:18 2026 p11bmc bmcwebd: [update_service.hpp:164] Log property has unexpected value
Fri Jun 26 11:27:18 2026 p11bmc bmcwebd: [dbus_utils.hpp:33] DBUS property error in property: AdditionalData, reason: 1
```

It is because the DBUS `AdditionalData` type has been changed from `as` to `a{ss}`.

For example, the output is changed like
```
$ busctl introspect xyz.openbmc_project.Logging /xyz/openbmc_project/logging/entry/9
.AdditionalData  property  as    6 "DESCRIPTION=Mismatch in IM value f…
==>
.AdditionalData  property  a{ss}  6 "DESCRIPTION" "Mismatch in IM value f…
```

Tested:
- Test on parsing of PEL record with the old and old logic.