### PR TITLE
Add UnavailableOffline state mapping and add getResourceStatus helper

### DIFF
--- a/redfish-core/include/utils/resource_utils.hpp
+++ b/redfish-core/include/utils/resource_utils.hpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#pragma once
+
+#include "async_resp.hpp"
+#include "dbus_utility.hpp"
+#include "error_messages.hpp"
+#include "generated/enums/resource.hpp"
+#include "logging.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace redfish
+{
+namespace resource_utils
+{
+
+/**
+ * @brief Fetches resource status.health from DBus interfaces
+ *
+ */
+inline void determineResourceHealth(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonPtr, bool functional)
+{
+    BMCWEB_LOG_DEBUG("determineResourceHealth");
+
+    if (!functional)
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
+            resource::Health::Critical;
+    }
+    else
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["Health"] =
+            resource::Health::OK;
+    }
+}
+
+inline void determineResourceState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool present,
+    bool available, const nlohmann::json::json_pointer& jsonPtr)
+{
+    BMCWEB_LOG_DEBUG("determineResourceState");
+
+    // Absent takes priority over unavailable
+    if (!present)
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+            resource::State::Absent;
+    }
+    else if (!available)
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+            resource::State::UnavailableOffline;
+    }
+    else
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+            resource::State::Enabled;
+    }
+}
+
+inline void getStatusAvailableState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonPtr, bool present,
+    const boost::system::error_code& ec, bool available)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for {}, ec {}", "Available",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        available = true;
+    }
+    determineResourceState(asyncResp, present, available, jsonPtr);
+}
+
+inline void getStatusPresentState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& path,
+    const nlohmann::json::json_pointer& jsonPtr,
+    const boost::system::error_code& ec, bool present)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for {}, ec {}", "Present",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        // Interface is missing, default to true for Enabled
+        present = true;
+    }
+    dbus::utility::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.State.Decorator.Availability", "Available",
+        std::bind_front(getStatusAvailableState, asyncResp, jsonPtr, present));
+}
+
+inline void getResourceState(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& path,
+    const nlohmann::json::json_pointer& jsonPtr)
+{
+    BMCWEB_LOG_DEBUG("getResourceStatus");
+    dbus::utility::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.Inventory.Item", "Present",
+        std::bind_front(getStatusPresentState, asyncResp, service, path,
+                        jsonPtr));
+}
+
+inline void afterGetResourceHealth(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const nlohmann::json::json_pointer& jsonPtr,
+    const boost::system::error_code& ec, bool functional)
+{
+    if (ec)
+    {
+        if (ec.value() != EBADR)
+        {
+            BMCWEB_LOG_ERROR("DBUS response error for {}, ec {}", "Functional",
+                             ec.value());
+            messages::internalError(asyncResp->res);
+            return;
+        }
+        // Interface missing, default to OK
+        functional = true;
+    }
+    determineResourceHealth(asyncResp, jsonPtr, functional);
+}
+
+/*
+ * @brief Retrieves the status of the resource's status.health
+ *
+ * Queries interface:
+ * - xyz.openbmc_project.State.Decorator.OperationalStatus::Functional
+ */
+inline void getResourceHealth(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& service, const std::string& path,
+    const nlohmann::json::json_pointer& jsonPtr)
+{
+    dbus::utility::getProperty<bool>(
+        *crow::connections::systemBus, service, path,
+        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
+        std::bind_front(afterGetResourceHealth, asyncResp, jsonPtr));
+}
+
+} // namespace resource_utils
+} // namespace redfish

--- a/redfish-core/lib/assembly.hpp
+++ b/redfish-core/lib/assembly.hpp
@@ -19,6 +19,7 @@
 #include "utils/asset_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -77,39 +78,30 @@ inline void getAssemblyLocationCode(
         });
 }
 
-inline void getAssemblyState(
+inline void getAssemblyReadyToRemove(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const auto& serviceName, const auto& assembly,
     const nlohmann::json::json_pointer& assemblyJsonPtr)
 {
-    asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["State"] =
-        resource::State::Enabled;
-
-    dbus::utility::getProperty<bool>(
-        serviceName, assembly, "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp, assemblyJsonPtr,
-         assembly](const boost::system::error_code& ec, const bool value) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
+    std::string fru = sdbusplus::message::object_path(assembly).filename();
+    if (fru == "panel0" || fru == "panel1")
+    {
+        dbus::utility::getProperty<bool>(
+            serviceName, assembly, "xyz.openbmc_project.Inventory.Item",
+            "Present",
+            [asyncResp, assemblyJsonPtr,
+             assembly](const boost::system::error_code& ec, const bool value) {
+                if (ec)
                 {
-                    BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
-                    messages::internalError(asyncResp->res);
+                    if (ec.value() != EBADR)
+                    {
+                        BMCWEB_LOG_ERROR("DBUS response error: {}", ec.value());
+                        messages::internalError(asyncResp->res);
+                    }
+                    return;
                 }
-                return;
-            }
 
-            if (!value)
-            {
-                asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["State"] =
-                    resource::State::Absent;
-            }
-
-            std::string fru =
-                sdbusplus::message::object_path(assembly).filename();
-            // Special handling for LCD and base panel CM.
-            if (fru == "panel0" || fru == "panel1")
-            {
+                // Special handling for LCD and base panel CM.
                 asyncResp->res.jsonValue[assemblyJsonPtr]["Oem"]["OpenBMC"]
                                         ["@odata.type"] =
                     "#OpenBMCAssembly.v1_0_0.OpenBMC";
@@ -118,38 +110,8 @@ inline void getAssemblyState(
                 // can be placed.
                 asyncResp->res.jsonValue[assemblyJsonPtr]["Oem"]["OpenBMC"]
                                         ["ReadyToRemove"] = !value;
-            }
-        });
-}
-
-void getAssemblyHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                       const auto& serviceName, const auto& assembly,
-                       const nlohmann::json::json_pointer& assemblyJsonPtr)
-{
-    asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["Health"] =
-        resource::Health::OK;
-
-    dbus::utility::getProperty<bool>(
-        serviceName, assembly,
-        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp, assemblyJsonPtr](const boost::system::error_code& ec,
-                                     bool functional) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error {}", ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!functional)
-            {
-                asyncResp->res.jsonValue[assemblyJsonPtr]["Status"]["Health"] =
-                    resource::Health::Critical;
-            }
-        });
+            });
+    }
 }
 
 /**
@@ -261,14 +223,17 @@ inline void afterGetDbusObject(
             }
             else if (interface == "xyz.openbmc_project.Inventory.Item")
             {
-                getAssemblyState(asyncResp, serviceName, assembly,
-                                 assemblyJsonPtr);
+                resource_utils::getResourceState(asyncResp, serviceName,
+                                                 assembly, assemblyJsonPtr);
+
+                getAssemblyReadyToRemove(asyncResp, serviceName, assembly,
+                                         assemblyJsonPtr);
             }
             else if (interface ==
                      "xyz.openbmc_project.State.Decorator.OperationalStatus")
             {
-                getAssemblyHealth(asyncResp, serviceName, assembly,
-                                  assemblyJsonPtr);
+                resource_utils::getResourceHealth(asyncResp, serviceName,
+                                                  assembly, assemblyJsonPtr);
             }
             else if (interface == "xyz.openbmc_project.State.ReadyToRemove")
             {

--- a/redfish-core/lib/cable.hpp
+++ b/redfish-core/lib/cable.hpp
@@ -18,6 +18,7 @@
 #include "utils/chassis_utils.hpp"
 #include "utils/collection.hpp"
 #include "utils/dbus_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 #include <sys/types.h>
@@ -156,35 +157,6 @@ inline void fillCablePartNumber(
                 return;
             }
             asyncResp->res.jsonValue["PartNumber"] = property;
-        });
-}
-
-inline void fillCableHealthState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& cableObjectPath, const std::string& service)
-{
-    dbus::utility::getProperty<bool>(
-        *crow::connections::systemBus, service, cableObjectPath,
-        "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp,
-         cableObjectPath](const boost::system::error_code& ec, bool present) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR(
-                        "get presence failed for Cable {} with error {}",
-                        cableObjectPath, ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!present)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::Absent;
-            }
         });
 }
 
@@ -490,7 +462,14 @@ inline void getCableProperties(
             }
             else if (interface == "xyz.openbmc_project.Inventory.Item")
             {
-                fillCableHealthState(asyncResp, cableObjectPath, service);
+                resource_utils::getResourceState(
+                    asyncResp, service, cableObjectPath, ""_json_pointer);
+            }
+            else if (interface ==
+                     "xyz.openbmc_project.State.Decorator.OperationalStatus")
+            {
+                resource_utils::getResourceHealth(
+                    asyncResp, service, cableObjectPath, ""_json_pointer);
             }
             else if (interface ==
                      "xyz.openbmc_project.Inventory.Decorator.Asset")

--- a/redfish-core/lib/fabric_adapters.hpp
+++ b/redfish-core/lib/fabric_adapters.hpp
@@ -19,6 +19,7 @@
 #include "utils/collection.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -62,59 +63,6 @@ inline void getFabricAdapterLocation(
             asyncResp->res
                 .jsonValue["Location"]["PartLocation"]["ServiceLabel"] =
                 property;
-        });
-}
-
-inline void getFabricAdapterState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& serviceName, const std::string& fabricAdapterPath)
-{
-    dbus::utility::getProperty<bool>(
-        serviceName, fabricAdapterPath, "xyz.openbmc_project.Inventory.Item",
-        "Present",
-        [asyncResp](const boost::system::error_code& ec, const bool present) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for State");
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!present)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::Absent;
-            }
-        });
-}
-
-inline void getFabricAdapterHealth(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& serviceName, const std::string& fabricAdapterPath)
-{
-    dbus::utility::getProperty<bool>(
-        serviceName, fabricAdapterPath,
-        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp](const boost::system::error_code& ec,
-                    const bool functional) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Health");
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!functional)
-            {
-                asyncResp->res.jsonValue["Status"]["Health"] =
-                    resource::Health::Critical;
-            }
         });
 }
 
@@ -259,9 +207,6 @@ inline void doAdapterGet(
     asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Systems/{}/FabricAdapters/{}", systemName, adapterId);
 
-    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
-    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
-
     asyncResp->res.jsonValue["Ports"]["@odata.id"] =
         boost::urls::format("/redfish/v1/Systems/{}/FabricAdapters/{}/Ports",
                             systemName, adapterId);
@@ -281,8 +226,10 @@ inline void doAdapterGet(
     getFabricAdapterLocation(asyncResp, serviceName, fabricAdapterPath);
     asset_utils::getAssetInfo(asyncResp, serviceName, fabricAdapterPath,
                               ""_json_pointer, true);
-    getFabricAdapterState(asyncResp, serviceName, fabricAdapterPath);
-    getFabricAdapterHealth(asyncResp, serviceName, fabricAdapterPath);
+    resource_utils::getResourceState(asyncResp, serviceName, fabricAdapterPath,
+                                     ""_json_pointer);
+    resource_utils::getResourceHealth(asyncResp, serviceName, fabricAdapterPath,
+                                      ""_json_pointer);
     getLocationIndicatorActive(asyncResp, fabricAdapterPath);
 
     // if the adapter also implements this interface, link the adapter schema to

--- a/redfish-core/lib/fabric_ports.hpp
+++ b/redfish-core/lib/fabric_ports.hpp
@@ -18,6 +18,7 @@
 #include "registries/privilege_registry.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -72,69 +73,6 @@ inline void getFabricPortLocation(
         std::bind_front(afterGetFabricPortLocation, asyncResp));
 }
 
-inline void afterGetFabricPortState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const boost::system::error_code& ec, bool present)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error for State, ec {}",
-                             ec.value());
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-
-    if (!present)
-    {
-        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Absent;
-    }
-}
-
-inline void getFabricPortState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& portPath, const std::string& serviceName)
-{
-    sdbusplus::asio::getProperty<bool>(
-        *crow::connections::systemBus, serviceName, portPath,
-        "xyz.openbmc_project.Inventory.Item", "Present",
-        std::bind_front(afterGetFabricPortState, asyncResp));
-}
-
-inline void afterGetFabricPortHealth(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const boost::system::error_code& ec, bool functional)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error for Health, ec {}",
-                             ec.value());
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-
-    if (!functional)
-    {
-        asyncResp->res.jsonValue["Status"]["Health"] =
-            resource::Health::Critical;
-    }
-}
-
-inline void getFabricPortHealth(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& portPath, const std::string& serviceName)
-{
-    sdbusplus::asio::getProperty<bool>(
-        *crow::connections::systemBus, serviceName, portPath,
-        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        std::bind_front(afterGetFabricPortHealth, asyncResp));
-}
-
 inline void getFabricPortProperties(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& systemName, const std::string& adapterId,
@@ -161,12 +99,11 @@ inline void getFabricPortProperties(
     nlohmann::json::json_pointer ptr("/Name");
     name_util::getPrettyName(asyncResp, portPath, serviceName, ptr);
 
-    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
-    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
-
     getFabricPortLocation(asyncResp, portPath, serviceName);
-    getFabricPortState(asyncResp, portPath, serviceName);
-    getFabricPortHealth(asyncResp, portPath, serviceName);
+    resource_utils::getResourceState(asyncResp, serviceName, portPath,
+                                     ""_json_pointer);
+    resource_utils::getResourceHealth(asyncResp, serviceName, portPath,
+                                      ""_json_pointer);
     getLocationIndicatorActive(asyncResp, portPath);
 }
 

--- a/redfish-core/lib/fan.hpp
+++ b/redfish-core/lib/fan.hpp
@@ -17,6 +17,7 @@
 #include "utils/fan_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -228,59 +229,6 @@ inline void addFanCommonProperties(crow::Response& resp,
     resp.jsonValue["Id"] = fanId;
     resp.jsonValue["@odata.id"] = boost::urls::format(
         "/redfish/v1/Chassis/{}/ThermalSubsystem/Fans/{}", chassisId, fanId);
-    resp.jsonValue["Status"]["State"] = resource::State::Enabled;
-    resp.jsonValue["Status"]["Health"] = resource::Health::OK;
-}
-
-inline void getFanHealth(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                         const std::string& fanPath, const std::string& service)
-{
-    dbus::utility::getProperty<bool>(
-        service, fanPath,
-        "xyz.openbmc_project.State.Decorator.OperationalStatus", "Functional",
-        [asyncResp](const boost::system::error_code& ec, const bool value) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Health {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!value)
-            {
-                asyncResp->res.jsonValue["Status"]["Health"] =
-                    resource::Health::Critical;
-            }
-        });
-}
-
-inline void getFanState(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-                        const std::string& fanPath, const std::string& service)
-{
-    dbus::utility::getProperty<bool>(
-        service, fanPath, "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp](const boost::system::error_code& ec, const bool value) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for State {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!value)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::Absent;
-            }
-        });
 }
 
 inline void getFanLocation(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
@@ -314,8 +262,10 @@ inline void afterGetValidFanObject(
     const std::string& fanPath, const std::string& service)
 {
     addFanCommonProperties(asyncResp->res, chassisId, fanId);
-    getFanState(asyncResp, fanPath, service);
-    getFanHealth(asyncResp, fanPath, service);
+    resource_utils::getResourceState(asyncResp, service, fanPath,
+                                     ""_json_pointer);
+    resource_utils::getResourceHealth(asyncResp, service, fanPath,
+                                      ""_json_pointer);
     asset_utils::getAssetInfo(asyncResp, service, fanPath, ""_json_pointer,
                               true);
     getFanLocation(asyncResp, fanPath, service);

--- a/redfish-core/lib/memory.hpp
+++ b/redfish-core/lib/memory.hpp
@@ -442,6 +442,7 @@ inline void assembleDimmProperties(
     const std::string* model = nullptr;
     const std::string* locationCode = nullptr;
     const bool* functional = nullptr;
+    const bool* available = nullptr;
 
     const bool success = sdbusplus::unpackPropertiesNoThrow(
         dbus_utils::UnpackErrorPrinter(), properties, "MemoryDataWidth",
@@ -454,7 +455,8 @@ inline void assembleDimmProperties(
         memoryConfiguredSpeedInMhz, "MemoryType", memoryType, "Channel",
         channel, "MemoryController", memoryController, "Slot", slot, "Socket",
         socket, "SparePartNumber", sparePartNumber, "Model", model,
-        "LocationCode", locationCode, "Functional", functional);
+        "LocationCode", locationCode, "Functional", functional, "Available",
+        available);
 
     if (!success)
     {
@@ -498,6 +500,11 @@ inline void assembleDimmProperties(
     {
         asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
             resource::State::Absent;
+    }
+    else if (available != nullptr && !*available)
+    {
+        asyncResp->res.jsonValue[jsonPtr]["Status"]["State"] =
+            resource::State::UnavailableOffline;
     }
 
     if (memoryTotalWidth != nullptr)

--- a/redfish-core/lib/power_supply.hpp
+++ b/redfish-core/lib/power_supply.hpp
@@ -17,6 +17,7 @@
 #include "utils/dbus_utils.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 #include "utils/time_utils.hpp"
 
 #include <asm-generic/errno.h>
@@ -223,91 +224,6 @@ inline void getValidPowerSupplyPath(
         });
 }
 
-inline void getPowerSupplyState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& path, bool available)
-{
-    dbus::utility::getProperty<bool>(
-        service, path, "xyz.openbmc_project.Inventory.Item", "Present",
-        [asyncResp,
-         available](const boost::system::error_code& ec, const bool value) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for State {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!value)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::Absent;
-            }
-            else if (!available)
-            {
-                asyncResp->res.jsonValue["Status"]["State"] =
-                    resource::State::UnavailableOffline;
-            }
-        });
-}
-
-inline void getPowerSupplyHealth(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& path, bool available)
-{
-    dbus::utility::getProperty<bool>(
-        service, path, "xyz.openbmc_project.State.Decorator.OperationalStatus",
-        "Functional",
-        [asyncResp,
-         available](const boost::system::error_code& ec, const bool value) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Health {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            if (!value || !available)
-            {
-                asyncResp->res.jsonValue["Status"]["Health"] =
-                    resource::Health::Critical;
-            }
-        });
-}
-
-inline void getPowerSupplyStateAndHealth(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& path)
-{
-    dbus::utility::getProperty<bool>(
-        service, path, "xyz.openbmc_project.State.Decorator.Availability",
-        "Available",
-        [asyncResp, service,
-         path](const boost::system::error_code& ec, const bool available) {
-            if (ec)
-            {
-                if (ec.value() != EBADR)
-                {
-                    BMCWEB_LOG_ERROR("DBUS response error for Available {}",
-                                     ec.value());
-                    messages::internalError(asyncResp->res);
-                }
-                return;
-            }
-
-            getPowerSupplyState(asyncResp, service, path, available);
-            getPowerSupplyHealth(asyncResp, service, path, available);
-        });
-}
-
 inline void getPowerSupplyAsset(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& service, const std::string& path)
@@ -504,7 +420,10 @@ inline void doPowerSupplyGet(
     asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
     asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
 
-    getPowerSupplyStateAndHealth(asyncResp, service, powerSupplyPath);
+    resource_utils::getResourceState(asyncResp, service, powerSupplyPath,
+                                     ""_json_pointer);
+    resource_utils::getResourceHealth(asyncResp, service, powerSupplyPath,
+                                      ""_json_pointer);
     getPowerSupplyAsset(asyncResp, service, powerSupplyPath);
     getPowerSupplyFirmwareVersion(asyncResp, service, powerSupplyPath);
     getPowerSupplyLocation(asyncResp, service, powerSupplyPath);

--- a/redfish-core/lib/processor.hpp
+++ b/redfish-core/lib/processor.hpp
@@ -22,6 +22,7 @@
 #include "utils/hw_isolation.hpp"
 #include "utils/json_utils.hpp"
 #include "utils/name_utils.hpp"
+#include "utils/resource_utils.hpp"
 
 #include <asm-generic/errno.h>
 
@@ -144,8 +145,9 @@ inline void getCpuDataByInterface(
     BMCWEB_LOG_DEBUG("Get CPU resources by interface.");
 
     // Set the default value of state
-    asyncResp->res.jsonValue["Status"]["State"] = resource::State::Enabled;
-    asyncResp->res.jsonValue["Status"]["Health"] = resource::Health::OK;
+    bool present = true;
+    bool available = true;
+    bool functional = true;
 
     for (const auto& interface : cpuInterfacesProperties)
     {
@@ -160,12 +162,17 @@ inline void getCpuDataByInterface(
                     messages::internalError(asyncResp->res);
                     return;
                 }
-                if (!*cpuPresent)
+                present = *cpuPresent;
+            }
+            else if (property.first == "Available")
+            {
+                const bool* cpuAvailable = std::get_if<bool>(&property.second);
+                if (cpuAvailable == nullptr)
                 {
-                    // Slot is not populated
-                    asyncResp->res.jsonValue["Status"]["State"] =
-                        resource::State::Absent;
+                    messages::internalError(asyncResp->res);
+                    return;
                 }
+                available = *cpuAvailable;
             }
             else if (property.first == "Functional")
             {
@@ -175,11 +182,7 @@ inline void getCpuDataByInterface(
                     messages::internalError(asyncResp->res);
                     return;
                 }
-                if (!*cpuFunctional)
-                {
-                    asyncResp->res.jsonValue["Status"]["Health"] =
-                        resource::Health::Critical;
-                }
+                functional = *cpuFunctional;
             }
             else if (property.first == "CoreCount")
             {
@@ -280,6 +283,10 @@ inline void getCpuDataByInterface(
             }
         }
     }
+    resource_utils::determineResourceState(asyncResp, present, available,
+                                           ""_json_pointer);
+    resource_utils::determineResourceHealth(asyncResp, ""_json_pointer,
+                                            functional);
 }
 
 inline void getCpuDataByService(
@@ -537,10 +544,11 @@ inline void getAcceleratorDataByService(
 
             const bool* functional = nullptr;
             const bool* present = nullptr;
+            const bool* available = nullptr;
 
             const bool success = sdbusplus::unpackPropertiesNoThrow(
                 dbus_utils::UnpackErrorPrinter(), properties, "Functional",
-                functional, "Present", present);
+                functional, "Present", present, "Available", available);
 
             if (!success)
             {
@@ -548,19 +556,23 @@ inline void getAcceleratorDataByService(
                 return;
             }
 
-            std::string state = "Enabled";
-            std::string health = "OK";
+            auto state = resource::State::Enabled;
+            auto health = resource::Health::OK;
 
             if (present != nullptr && !*present)
             {
-                state = "Absent";
+                state = resource::State::Absent;
+            }
+            else if (available != nullptr && !*available)
+            {
+                state = resource::State::UnavailableOffline;
             }
 
             if (functional != nullptr && !*functional)
             {
-                if (state == "Enabled")
+                if (state == resource::State::Enabled)
                 {
-                    health = "Critical";
+                    health = resource::Health::Critical;
                 }
             }
 
@@ -1026,65 +1038,6 @@ inline void getSubProcessorsCoreHealth(
         });
 }
 
-inline void afterGetSubProcessorsCorePresent(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const boost::system::error_code& ec, bool present)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error for Available {}",
-                             ec.value());
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-
-    if (!present)
-    {
-        asyncResp->res.jsonValue["Status"]["State"] = resource::State::Absent;
-        return;
-    }
-}
-
-inline void afterGetSubProcessorsCoreAvailable(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& corePath,
-    const boost::system::error_code& ec, bool available)
-{
-    if (ec)
-    {
-        if (ec.value() != EBADR)
-        {
-            BMCWEB_LOG_ERROR("DBUS response error, ec: {}", ec.value());
-            messages::internalError(asyncResp->res);
-        }
-        return;
-    }
-
-    if (!available)
-    {
-        asyncResp->res.jsonValue["Status"]["State"] =
-            resource::State::UnavailableOffline;
-    }
-
-    dbus::utility::getProperty<bool>(
-        service, corePath, "xyz.openbmc_project.Inventory.Item", "Present",
-        std::bind_front(afterGetSubProcessorsCorePresent, asyncResp));
-}
-
-inline void getSubProcessorsCoreState(
-    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
-    const std::string& service, const std::string& corePath)
-{
-    dbus::utility::getProperty<bool>(
-        service, corePath, "xyz.openbmc_project.State.Decorator.Availability",
-        "Available",
-        std::bind_front(afterGetSubProcessorsCoreAvailable, asyncResp, service,
-                        corePath));
-}
-
 inline void getEnabledStatus(
     const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
     const std::string& service, const std::string& objPath,
@@ -1133,15 +1086,20 @@ inline void getSubProcessorsCoreData(
             {
                 name_util::getPrettyName(asyncResp, corePath, service,
                                          "/Name"_json_pointer);
+                resource_utils::getResourceState(asyncResp, service, corePath,
+                                                 ""_json_pointer);
             }
             else if (intf == "xyz.openbmc_project.Object.Enable")
             {
                 getEnabledStatus(asyncResp, service, corePath, intf);
             }
+            else if (intf ==
+                     "xyz.openbmc_project.State.Decorator.OperationalStatus")
+            {
+                resource_utils::getResourceHealth(asyncResp, service, corePath,
+                                                  ""_json_pointer);
+            }
         }
-
-        getSubProcessorsCoreState(asyncResp, service, corePath);
-        getSubProcessorsCoreHealth(asyncResp, service, corePath);
 
         if constexpr (BMCWEB_HW_ISOLATION)
         {

--- a/test/meson.build
+++ b/test/meson.build
@@ -40,6 +40,7 @@ srcfiles_unittest = files(
     'redfish-core/include/utils/ip_utils_test.cpp',
     'redfish-core/include/utils/json_utils_test.cpp',
     'redfish-core/include/utils/query_param_test.cpp',
+    'redfish-core/include/utils/resource_utils_test.cpp',
     'redfish-core/include/utils/sensor_utils_test.cpp',
     'redfish-core/include/utils/stl_utils_test.cpp',
     'redfish-core/include/utils/time_utils_test.cpp',

--- a/test/redfish-core/include/utils/resource_utils_test.cpp
+++ b/test/redfish-core/include/utils/resource_utils_test.cpp
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright OpenBMC Authors
+#include "async_resp.hpp"
+#include "generated/enums/resource.hpp"
+#include "utils/resource_utils.hpp"
+
+#include <asm-generic/errno.h>
+
+#include <boost/beast/http/status.hpp>
+#include <boost/system/error_code.hpp>
+#include <nlohmann/json.hpp>
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+namespace redfish::resource_utils
+{
+namespace
+{
+
+std::shared_ptr<bmcweb::AsyncResp> createAsyncResp()
+{
+    return std::make_shared<bmcweb::AsyncResp>();
+}
+
+// Tests for determineResourceState
+
+TEST(DetermineResourceState, Absent)
+{
+    auto asyncResp = createAsyncResp();
+    bool present = false;
+    bool available = true;
+
+    determineResourceState(asyncResp, present, available, ""_json_pointer);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Absent);
+}
+
+TEST(DetermineResourceState, UnavailableOffline)
+{
+    auto asyncResp = createAsyncResp();
+    bool present = true;
+    bool available = false;
+
+    determineResourceState(asyncResp, present, available, ""_json_pointer);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::UnavailableOffline);
+}
+
+TEST(DetermineResourceState, Enabled)
+{
+    auto asyncResp = createAsyncResp();
+    bool present = true;
+    bool available = true;
+
+    determineResourceState(asyncResp, present, available, ""_json_pointer);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Enabled);
+}
+
+TEST(DetermineResourceState, AbsentTakesPriorityOverUnavailable)
+{
+    auto asyncResp = createAsyncResp();
+    bool present = false;
+    bool available = false;
+
+    determineResourceState(asyncResp, present, available, ""_json_pointer);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Absent);
+}
+
+TEST(DetermineResourceState, WithJsonPointer)
+{
+    auto asyncResp = createAsyncResp();
+    bool present = true;
+    bool available = true;
+
+    nlohmann::json::json_pointer ptr("/Assemblies/0");
+    determineResourceState(asyncResp, present, available, ptr);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Assemblies"][0]["Status"]["State"],
+              resource::State::Enabled);
+}
+
+// Tests for determineResourceHealth
+
+TEST(DetermineResourceHealth, OK)
+{
+    auto asyncResp = createAsyncResp();
+    bool functional = true;
+
+    determineResourceHealth(asyncResp, ""_json_pointer, functional);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["Health"],
+              resource::Health::OK);
+}
+
+TEST(DetermineResourceHealth, Critical)
+{
+    auto asyncResp = createAsyncResp();
+    bool functional = false;
+
+    determineResourceHealth(asyncResp, ""_json_pointer, functional);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["Health"],
+              resource::Health::Critical);
+}
+
+TEST(DetermineResourceHealth, WithJsonPointer)
+{
+    auto asyncResp = createAsyncResp();
+    bool functional = false;
+    nlohmann::json::json_pointer ptr("/Resource1");
+
+    determineResourceHealth(asyncResp, ptr, functional);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Resource1"]["Status"]["Health"],
+              resource::Health::Critical);
+}
+
+// Integration-style tests
+
+TEST(ResourceUtils, MultipleResourcesWithDifferentStates)
+{
+    auto asyncResp = createAsyncResp();
+
+    // Resource 1: Absent
+    determineResourceState(asyncResp, false, true, "/Resource1"_json_pointer);
+
+    // Resource 2: UnavailableOffline
+    determineResourceState(asyncResp, true, false, "/Resource2"_json_pointer);
+
+    // Resource 3: Enabled
+    determineResourceState(asyncResp, true, true, "/Resource3"_json_pointer);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Resource1"]["Status"]["State"],
+              resource::State::Absent);
+    EXPECT_EQ(asyncResp->res.jsonValue["Resource2"]["Status"]["State"],
+              resource::State::UnavailableOffline);
+    EXPECT_EQ(asyncResp->res.jsonValue["Resource3"]["Status"]["State"],
+              resource::State::Enabled);
+}
+
+TEST(ResourceUtils, StateAndHealthSeparately)
+{
+    auto asyncResp = createAsyncResp();
+
+    determineResourceState(asyncResp, true, true, ""_json_pointer);
+    determineResourceHealth(asyncResp, ""_json_pointer, false);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Enabled);
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["Health"],
+              resource::Health::Critical);
+}
+
+TEST(ResourceUtils, StateAndHealthWithJsonPointer)
+{
+    auto asyncResp = createAsyncResp();
+    nlohmann::json::json_pointer ptr("/Component");
+
+    determineResourceState(asyncResp, true, false, ptr);
+    determineResourceHealth(asyncResp, ptr, true);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Component"]["Status"]["State"],
+              resource::State::UnavailableOffline);
+    EXPECT_EQ(asyncResp->res.jsonValue["Component"]["Status"]["Health"],
+              resource::Health::OK);
+}
+TEST(GetStatusAvailableState, MissingInterfaceDefaultsToEnabled)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(EBADR, boost::system::generic_category());
+
+    // EBADR should cause Enabled
+    getStatusAvailableState(asyncResp, ""_json_pointer, true, ec, false);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Enabled);
+}
+
+TEST(GetStatusAvailableState, MissingInterfacePreservesAbsent)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(EBADR, boost::system::generic_category());
+
+    getStatusAvailableState(asyncResp, ""_json_pointer, false, ec, false);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["State"],
+              resource::State::Absent);
+}
+
+TEST(GetStatusAvailableState, NonMissingInterfaceError)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(ENONET, boost::system::generic_category());
+
+    getStatusAvailableState(asyncResp, ""_json_pointer, false, ec, true);
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_FALSE(asyncResp->res.jsonValue["Status"].contains("State"));
+}
+TEST(GetStatusPresentState, NonMissingInterfaceError)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(ENONET, boost::system::generic_category());
+
+    getStatusPresentState(asyncResp, "Service", "Path", ""_json_pointer, ec,
+                          true);
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_FALSE(asyncResp->res.jsonValue["Status"].contains("State"));
+}
+
+TEST(AfterGetResourceHealth, MissingInterfaceDefaultsToOK)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(EBADR, boost::system::generic_category());
+
+    // The bool value supplied on error is false, but on EBADR result in OK
+    afterGetResourceHealth(asyncResp, ""_json_pointer, ec, false);
+
+    EXPECT_EQ(asyncResp->res.jsonValue["Status"]["Health"],
+              resource::Health::OK);
+}
+
+TEST(AfterGetResourceHealth, NonMissingInterfaceError)
+{
+    auto asyncResp = createAsyncResp();
+
+    boost::system::error_code ec(ENONET, boost::system::generic_category());
+
+    afterGetResourceHealth(asyncResp, ""_json_pointer, ec, true);
+    EXPECT_EQ(asyncResp->res.result(),
+              boost::beast::http::status::internal_server_error);
+    EXPECT_FALSE(asyncResp->res.jsonValue["Status"].contains("Health"));
+}
+
+} // namespace
+} // namespace redfish::resource_utils


### PR DESCRIPTION
1. Added a utility function to reduce code duplication for retrieving
resource's Status.State and Status.Health
2. Mapped D-Bus `Available` to Redfish `UnavailableOffline`

Tested:
- Build successfully
- Unit tests passed
- Sent requests and received Status.State and Status.Health as expected
  with the new mapping
```
curl -k -v https://${bmc}/redfish/v1/Systems/system/Processors/mcm/SubProcessors/core0
```
Results with
```
{
  "@odata.id": "/redfish/v1/Systems/system/Processors/mcm/SubProcessors/core0",
  "@odata.type": "#Processor.v1_18_0.Processor",
  "Enabled": true,
  "Id": "core0",
  "Name": "Node 0 processor module Core 0",
  "Status": {
    "Health": "OK",
    "State": "UnavailableOffline"
 }
```
Upstream commits are:
utils: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/92845
cable: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/78685
fan: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/92846
pcie: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/92847
fabric adapters: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93368
fabric ports: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93369
assembly: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93370
memory: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93371
processors and accelerators: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93372
subprocessor: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/92439?tab=comments
power supply: https://gerrit.openbmc.org/c/openbmc/bmcweb/+/93373