### PR TITLE
RBMC: Handle Status/Health for manager

### DIFF
--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -47,15 +47,24 @@ inline redundancy::RedundancyMode dBusRedundancyEnabledToRedfish(
     return redundancy::RedundancyMode::NotRedundant;
 }
 
-inline resource::State getRedundantState(bool failoversAllowed,
-                                         bool redundancyEnabled)
+inline resource::State getRedundantState(bool failoversAllowed)
 {
-    if (!redundancyEnabled || !failoversAllowed)
+    if (!failoversAllowed)
     {
         return resource::State::Disabled;
     }
 
     return resource::State::Enabled;
+}
+
+inline resource::Health getRedundantHealth(bool failoversAllowed)
+{
+    if (!failoversAllowed)
+    {
+        return resource::Health::Warning;
+    }
+
+    return resource::Health::OK;
 }
 
 inline void getRedundantData(
@@ -124,16 +133,16 @@ inline void getRedundantData(
     {
         redundantObject["Mode"] =
             dBusRedundancyEnabledToRedfish(*redundancyEnabled);
-
-        if (failoversAllowed != nullptr)
-        {
-            redundantObject["Status"]["State"] =
-                getRedundantState(*failoversAllowed, *redundancyEnabled);
-        }
     }
 
-    // TODO: Handle badpath for health
-    redundantObject["Status"]["Health"] = resource::Health::OK;
+    if (failoversAllowed != nullptr)
+    {
+        redundantObject["Status"]["State"] =
+            getRedundantState(*failoversAllowed);
+        redundantObject["Status"]["Health"] =
+            getRedundantHealth(*failoversAllowed);
+        // TODO: Handle Status/Conditions
+    }
 
     if (redundancyMinimum != nullptr)
     {


### PR DESCRIPTION
The Status/Health of the Redundancy property of the Manager response should reflect the current state. When redundancy is enabled and failovers are allowed the Health should reflect OK. When redundancy is not enabled or not allowed the Health should indicate Warning.

Tested:
 - Redfish service validator passes for Managers

```
Note: Tested on both active and passive BMC. Mode and Status for
Redundancy are the same on each in each scenario.

/* Redundancy is enabled and allowed */
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" https://${BMC_IP}/redfish/v1/Managers/bmc
{
  [...]
    "Redundancy": [
    {
[...]
      "Mode": "Failover",
[...]
      "Status": {
        "Health": "OK",
        "State": "Enabled"

      }
    }
  ],
  "Redundancy@odata.count": 1,
[...]

/* Redundancy is disabled */
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" https://${BMC_IP}/redfish/v1/Managers/bmc
{
  [...]
    "Redundancy": [
    {
[...]
      "Mode": "NotRedundant",
[...]
      "Status": {
        "Health": "Warning",
        "State": "Disabled"
      }
    }
  ],
  "Redundancy@odata.count": 1,
[...]

/* Redundancy is enabled but not allowed */
curl -k -H "X-Auth-Token: $token" -H "Content-Type: application/json" https://${BMC_IP}/redfish/v1/Managers/bmc
{
  [...]
    "Redundancy": [
    {
[...]
      "Mode": "Failover",
[...]
      "Status": {
        "Health": "Warning",
        "State": "Disabled"
      }
    }
  ],
  "Redundancy@odata.count": 1,
[...]

```