### PR TITLE
1210: Generate 64 bit serial numbers

### DIFF
--- a/src/ssl_key_handler.cpp
+++ b/src/ssl_key_handler.cpp
@@ -286,9 +286,10 @@ std::string generateSslCertificate(const std::string& cn)
             // number If this is not random, regenerating certs throws browser
             // errors
             bmcweb::OpenSSLGenerator gen;
-            std::uniform_int_distribution<int> dis(
-                1, std::numeric_limits<int>::max());
-            int serial = dis(gen);
+            std::uniform_int_distribution<uint64_t> dis(
+                std::numeric_limits<uint64_t>::min(),
+                std::numeric_limits<uint64_t>::max());
+            int64_t serial = static_cast<int64_t>(dis(gen));
 
             ASN1_INTEGER_set(X509_get_serialNumber(x509), serial);
 


### PR DESCRIPTION
Even though the certificate is self signed, we should pass as many certificate tests as possible.  testssl.sh prints
```
 Serial 4B32D4F0   NOT ok: length should be >= 64 bits entropy (is: 4 bytes)
```

On our default certificate.  This is relatively easy to fix.

Change-Id: Ib1eb07b637ebf49ecf954b3d98ced9e9ef0f5a34