### PR TITLE
1210: Fix compile error

### DIFF
--- a/src/ssl_key_handler.cpp
+++ b/src/ssl_key_handler.cpp
@@ -289,7 +289,7 @@ std::string generateSslCertificate(const std::string& cn)
             std::uniform_int_distribution<uint64_t> dis(
                 std::numeric_limits<uint64_t>::min(),
                 std::numeric_limits<uint64_t>::max());
-            int64_t serial = static_cast<int64_t>(dis(gen));
+            long int serial = static_cast<long int>(dis(gen));
 
             ASN1_INTEGER_set(X509_get_serialNumber(x509), serial);
 


### PR DESCRIPTION
Previous PR causes a compile error like
```
16:22:27  | ../git/src/ssl_key_handler.cpp:294:59: error: conversion from 'int64_t' {aka 'long long int'} to 'long int' may change value [-Werror=conversion]
16:22:27  |   294 |             ASN1_INTEGER_set(X509_get_serialNumber(x509), serial);
16:22:27  |       |                                                           ^~~~~~
16:22:27  | cc1plus: all warnings being treated as errors
```

This fixes it.