### PR TITLE
redfish: Sort EventLog entries by Created timestamp

### DIFF
--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -1784,7 +1784,7 @@ inline void afterLogEntriesGetManagedObjects(
                                              entriesArray.emplace_back());
     }
 
-    redfish::json_util::sortJsonArrayByKey(entriesArray, "Id");
+    redfish::json_util::sortJsonArrayByKey(entriesArray, "Created");
     asyncResp->res.jsonValue["Members@odata.count"] = entriesArray.size();
     asyncResp->res.jsonValue["Members"] = std::move(entriesArray);
 }


### PR DESCRIPTION
EventLog entries were sorted by "Id" with alphanumeric comparison. While this avoids the multi-digit lexicographic sorting, "Id" is an opaque identifier with no guaranteed relationship to event time.

"Created" carries a timestamp that is guaranteed to match chronological order. This makes the sort both correct by construction and intuitive to people expecting entries in event-time sequence.

Change sortJsonArrayByKey to use "Created" instead of "Id" as the sort key for the EventLog Entries collection.

Tested: Verified that EventLog entries sorted by Created timestamp match the expected chronological order. Confirmed via D-Bus that Timestamp values increase monotonically with Id, producing identical ordering.