### PR TITLE
http: Add SIGUSR1 to signal_set

### DIFF
--- a/http/http_server.hpp
+++ b/http/http_server.hpp
@@ -55,7 +55,10 @@ class Server
         // NOLINTNEXTLINE(misc-include-cleaner)
         signals(getIoContext(), SIGINT, SIGTERM, SIGHUP), handler(handlerIn),
         sslContextFactory(std::move(contextFactory))
-    {}
+    {
+        // NOLINTNEXTLINE(misc-include-cleaner)
+        signals.add(SIGUSR1);
+    }
     std::string getCachedDateStrImpl()
     {
         std::chrono::steady_clock::time_point now =


### PR DESCRIPTION
https://github.com/ibm-openbmc/bmcweb/pull/1467 broke this

This function is downstream only. 

We should talk about this function.. Ideally something upstream.. A true flight recorder..

The boost::asio::signal_set in Server's constructor was registered with only SIGINT, SIGTERM, and SIGHUP. SIGUSR1 was handled in the startAsyncWaitForSignal() callback to write the current session snapshot to disk for BMC dumps, but was never added to the set.

Because SIGUSR1 was not intercepted by Boost.Asio, the OS applied its default disposition for the signal: terminate the process. This caused bmcweb to be killed (status=10/USR1) every time a BMC dump was initiated, as dreport sends SIGUSR1 to collect the session data file.

Add SIGUSR1 to the signal_set constructor so Boost.Asio intercepts it, allowing the existing handler to call writeCurrentSessionData() and re-arm the signal wait. bmcweb now survives the dump collection.