### PR TITLE
Fix Redfish Service Validator 3.1.6 issues

### DIFF
--- a/redfish-core/lib/environment_metrics.hpp
+++ b/redfish-core/lib/environment_metrics.hpp
@@ -8,6 +8,7 @@
 #include "str_utility.hpp"
 #include "utils/chassis_utils.hpp"
 #include "utils/fan_utils.hpp"
+#include "utils/sensor_utils.hpp"
 
 #include <boost/url/format.hpp>
 
@@ -26,18 +27,22 @@ inline void
                         const std::string& chassisId,
                         const std::string& fanSensorPath, double value)
 {
-    std::string fanSensorName =
-        sdbusplus::message::object_path(fanSensorPath).filename();
-    if (fanSensorName.empty())
+    sdbusplus::message::object_path sensorPath(fanSensorPath);
+    std::string fanSensorName = sensorPath.filename();
+    std::string fanSensorType = sensorPath.parent_path().filename();
+    if (fanSensorName.empty() || fanSensorType.empty())
     {
         BMCWEB_LOG_ERROR("Fan Sensor name is empty and invalid");
         messages::internalError(asyncResp->res);
         return;
     }
 
+    std::string fanSensorId =
+        sensor_utils::getSensorId(fanSensorName, fanSensorType);
+
     nlohmann::json::object_t item;
     item["DataSourceUri"] = boost::urls::format(
-        "/redfish/v1/Chassis/{}/Sensors/{}", chassisId, fanSensorName);
+        "/redfish/v1/Chassis/{}/Sensors/{}", chassisId, fanSensorId);
     item["DeviceName"] = "Chassis #" + fanSensorName;
     item["SpeedRPM"] = value;
 
@@ -178,8 +183,6 @@ inline void afterGetPropertyForPowerWatts(
         }
         return;
     }
-    asyncResp->res.jsonValue["PowerWatts"]["@odata.id"] = boost::urls::format(
-        "/redfish/v1/Chassis/{}/Sensors/power_total_power", chassisId);
     asyncResp->res.jsonValue["PowerWatts"]["DataSourceUri"] =
         boost::urls::format("/redfish/v1/Chassis/{}/Sensors/power_total_power",
                             chassisId);

--- a/redfish-core/lib/license_service.hpp
+++ b/redfish-core/lib/license_service.hpp
@@ -182,13 +182,11 @@ inline void getLicenseEntryCollection(
                 }
                 entriesArray.push_back({});
                 nlohmann::json& thisEntry = entriesArray.back();
-                thisEntry["@odata.id"] = std::format(
+                thisEntry["@odata.id"] = boost::urls::format(
                     "/redfish/v1/LicenseService/Licenses/{}", entryID);
-                thisEntry["Id"] = entryID;
-                thisEntry["Name"] = entryID + " License Entry";
-                asyncResp->res.jsonValue["Members@odata.count"] =
-                    entriesArray.size();
             }
+            asyncResp->res.jsonValue["Members@odata.count"] =
+                entriesArray.size();
         });
 }
 

--- a/redfish-core/lib/log_services.hpp
+++ b/redfish-core/lib/log_services.hpp
@@ -3314,10 +3314,12 @@ inline void requestRoutesDBusCELogEntry(App& app)
 
 inline void
     displayOemPelAttachment(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                            const boost::urls::url& urlLogEntryPrefix,
                             const std::string& entryID)
 {
-    auto respHandler = [asyncResp, entryID](const boost::system::error_code& ec,
-                                            const std::string& pelJson) {
+    auto respHandler = [asyncResp, urlLogEntryPrefix,
+                        entryID](const boost::system::error_code& ec,
+                                 const std::string& pelJson) {
         if (ec.value() == EBADR)
         {
             messages::resourceNotFound(asyncResp->res, "OemPelAttachment",
@@ -3330,6 +3332,14 @@ inline void
             messages::internalError(asyncResp->res);
             return;
         }
+
+        asyncResp->res.jsonValue["@odata.id"] = boost::urls::format(
+            "{}/{}/OemPelAttachment", urlLogEntryPrefix, entryID);
+        asyncResp->res.jsonValue["@odata.type"] =
+            "#IBMLogEntryAttachment.v1_0_0.IBMLogEntryAttachment";
+
+        asyncResp->res.jsonValue["Name"] = "OemPelAttachment";
+        asyncResp->res.jsonValue["Id"] = "OemPelAttachment";
 
         asyncResp->res.jsonValue["Oem"]["IBM"]["PelJson"] = pelJson;
         asyncResp->res.jsonValue["Oem"]["IBM"]["@odata.type"] =
@@ -3390,7 +3400,12 @@ inline void requestRoutesDBusEventLogEntryDownloadPelJson(App& app)
                                                        "LogEntry", entryID);
                             return;
                         }
-                        displayOemPelAttachment(asyncResp, entryID);
+                        boost::urls::url urlLogEntryPrefix =
+                            boost::urls::format(
+                                "/redfish/v1/Systems/{}/LogServices/EventLog/Entries",
+                                BMCWEB_REDFISH_SYSTEM_URI_NAME);
+                        displayOemPelAttachment(asyncResp, urlLogEntryPrefix,
+                                                entryID);
                     };
                 redfish::error_log_utils::getHiddenPropertyValue(
                     asyncResp, entryID, std::move(eventLogAttachmentCallback));
@@ -3432,7 +3447,12 @@ inline void requestRoutesDBusCELogEntryDownloadPelJson(App& app)
                                                        "LogEntry", entryID);
                             return;
                         }
-                        displayOemPelAttachment(asyncResp, entryID);
+                        boost::urls::url urlLogEntryPrefix =
+                            boost::urls::format(
+                                "/redfish/v1/Systems/{}/LogServices/CELog/Entries",
+                                BMCWEB_REDFISH_SYSTEM_URI_NAME);
+                        displayOemPelAttachment(asyncResp, urlLogEntryPrefix,
+                                                entryID);
                     };
                 redfish::error_log_utils::getHiddenPropertyValue(
                     asyncResp, entryID, std::move(eventLogAttachmentCallback));

--- a/redfish-core/lib/pcie.hpp
+++ b/redfish-core/lib/pcie.hpp
@@ -918,7 +918,7 @@ inline void addPCIeFunctionList(
             std::to_string(functionNum));
         pcieFunctionList.emplace_back(std::move(pcieFunction));
     }
-    res.jsonValue["PCIeFunctions@odata.count"] = pcieFunctionList.size();
+    res.jsonValue["Members@odata.count"] = pcieFunctionList.size();
 }
 
 inline void handlePCIeFunctionCollectionGet(

--- a/redfish-core/lib/systems.hpp
+++ b/redfish-core/lib/systems.hpp
@@ -2289,7 +2289,7 @@ inline void requestRoutesSystemActionsOemExecutePanelFunction(App& app)
 {
     BMCWEB_ROUTE(
         app,
-        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction/")
+        "/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.ExecutePanelFunction/")
         .privileges(redfish::privileges::postComputerSystem)
         .methods(boost::beast::http::verb::post)(std::bind_front(
             handleSystemActionsOemExecutePanelFunctionPost, std::ref(app)));
@@ -2329,6 +2329,7 @@ inline void getChapData(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp)
             oemIBM["@odata.type"] = "#IBMComputerSystem.v1_0_0.IBM";
 
             nlohmann::json& chapData = oemIBM["ChapData"];
+            chapData["@odata.type"] = "#IBMComputerSystem.v1_0_0.ChapData";
             chapData["ChapName"] = *chapName;
             chapData["ChapSecret"] = *chapSecret;
         });
@@ -2899,8 +2900,8 @@ inline void
     getEnabledPanelFunctions(asyncResp);
 
     nlohmann::json& actionOem = asyncResp->res.jsonValue["Actions"]["Oem"];
-    actionOem["#IBMComputerSystem.v1_0_0.ExecutePanelFunction"]["target"] =
-        "/redfish/v1/Systems/system/Actions/Oem/IBM/IBMComputerSystem.ExecutePanelFunction";
+    actionOem["#IBMComputerSystem.ExecutePanelFunction"]["target"] =
+        "/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.ExecutePanelFunction";
 
     // ChapData
     getChapData(asyncResp);

--- a/redfish-core/lib/update_service.hpp
+++ b/redfish-core/lib/update_service.hpp
@@ -957,8 +957,7 @@ inline void requestRoutesUpdateService(App& app)
                 BMCWEB_HTTP_BODY_LIMIT * 1024 * 1024;
             nlohmann::json& updateSvcConUpdate =
                 asyncResp->res
-                    .jsonValue["Actions"]["Oem"]["#OemUpdateService.v1_0_0."
-                                                 "ConcurrentUpdate"];
+                    .jsonValue["Actions"]["Oem"]["#OemUpdateService.ConcurrentUpdate"];
             updateSvcConUpdate["target"] =
                 "/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate";
 

--- a/redfish-core/schema/oem/ibm/csdl/IBMFabricAdapter_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMFabricAdapter_v1.xml
@@ -27,7 +27,7 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="IBMFabricAdapter Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMFabricAdapter.IBM"/>
+        <Property Name="IBM" Type="IBMFabricAdapter.v1_0_0.IBM"/>
       </ComplexType>
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>

--- a/redfish-core/schema/oem/ibm/csdl/IBMLogEntryAttachment_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMLogEntryAttachment_v1.xml
@@ -18,14 +18,17 @@
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
     </Schema>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="IBMLogEntryAttachment.v1_0_0">
-      <Annotation Term="Redfish.OwningEntity" String="OpenBMC"/>
+      <Annotation Term="Redfish.OwningEntity" String="IBM"/>
       <Annotation Term="Redfish.Release" String="1.0"/>
-      <ComplexType Name="Oem" BaseType="Resource.OemObject">
-        <Annotation Term="OData.AdditionalProperties" Bool="true"/>
-        <Annotation Term="OData.Description" String="IBMLogEntryAttachment Oem properties."/>
-        <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMLogEntryAttachment.v1_0_0.IBM"/>
-      </ComplexType>
+      <EntityType Name="IBMLogEntryAttachment" BaseType="Resource.v1_0_0.Resource" Abstract="true">
+        <ComplexType Name="Oem" BaseType="Resource.OemObject">
+          <Annotation Term="OData.AdditionalProperties" Bool="true"/>
+          <Annotation Term="OData.Description" String="IBMLogEntryAttachment Oem properties."/>
+          <Annotation Term="OData.AutoExpand"/>
+          <Property Name="IBM" Type="IBMLogEntryAttachment.v1_0_0.IBM"/>
+        </ComplexType>
+      </EntityType>
+
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
@@ -39,6 +42,7 @@
           <Annotation Term="OData.Description" String="Audit Log in Json format."/>
         </Property>
       </ComplexType>
+
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMManagerAccount_v1.xml
@@ -26,13 +26,13 @@
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="IBM" Type="IBMManagerAccount.v1_0_0.IBM"/>
       </ComplexType>
-      <ComplexType Name="IBM">
+      <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="ACF" Type="IBMManagerAccount.v1_0_0.ACF"/>
       </ComplexType>
-      <ComplexType Name="ACF">
+      <ComplexType Name="ACF" BaseType="Resource.OemObject">
         <Annotation Term="OData.Description" String="A collection of ACF properties."/>
         <Annotation Term="OData.LongDescription" String="A collection of access control file properties."/>
         <Annotation Term="OData.AdditionalProperties" Bool="false"/>

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeDevice_v1.xml
@@ -40,11 +40,11 @@
         </Property>
       </ComplexType>
       <ComplexType Name="PCIeLinks" BaseType="Resource.OemObject">
-        <Property Name="PCIeSlot" Type="Resource.Resource">
+        <NavigationProperty Name="PCIeSlot" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="PCIe Slot Link"/>
           <Annotation Term="OData.LongDescription" String="Represent PCIe Slot Link which has all PCIe device list."/>
-        </Property>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMPCIeSlots_v1.xml
@@ -49,15 +49,15 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="AssociatedAssembly" Type="Resource.Resource">
+        <NavigationProperty Name="AssociatedAssembly" Type="Resource.Resource">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="Represent association slot with assembly."/>
-        </Property>
-        <Property Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
+        </NavigationProperty>
+        <NavigationProperty Name="UpstreamFabricAdapters" Type="Collection(FabricAdapter.FabricAdapter)">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The upstream fabric adapters."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain an array of links to the upstream fabric adapters."/>
-        </Property>
+        </NavigationProperty>
       </ComplexType>
     </Schema>
   </edmx:DataServices>

--- a/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/IBMServiceRoot_v1.xml
@@ -27,38 +27,38 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="IBMServiceRoot Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="IBM" Type="IBMServiceRoot.IBM"/>
+        <Property Name="IBM" Type="IBMServiceRoot.v1_0_0.IBM"/>
       </ComplexType>
       <ComplexType Name="IBM" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for IBM."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="Model" Type="IBMServiceRoot.IBM">
+        <Property Name="Model" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The product name for this system, without the manufacturer name."/>
           <Annotation Term="OData.LongDescription" String="This property shall describe how the manufacturer refers to this system.  Typically, this value is the product name for this system without the manufacturer name."/>
         </Property>
-        <Property Name="SerialNumber" Type="IBMServiceRoot.IBM">
+        <Property Name="SerialNumber" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="The serial number for this system."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the serial number for the system."/>
         </Property>
-        <Property Name="DateTime" Type="IBMServiceRoot.IBM">
+        <Property Name="DateTime" Type="Edm.DateTimeOffset">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The current date and time with UTC offset of the manager."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the current date and time with UTC offset of the manager."/>
         </Property>
-        <Property Name="DateTimeLocalOffset" Type="IBMServiceRoot.IBM">
+        <Property Name="DateTimeLocalOffset" Type="Edm.String">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/ReadWrite"/>
           <Annotation Term="OData.Description" String="The time offset from UTC that the DateTime property is in `+HH:MM` format."/>
           <Annotation Term="OData.LongDescription" String="This property shall contain the offset from UTC time that the DateTime property contains.  If both DateTime and DateTimeLocalOffset are provided in modification requests, services shall apply DateTimeLocalOffset after DateTime is applied."/>
         </Property>
-        <Property Name="ACFWindowActive" Type="IBMServiceRoot.IBM">
+        <Property Name="ACFWindowActive" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="An indication of whether the time window for an unauthorized agent to upload an ACF is active."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the time window for an unauthorized agent to upload an ACF is active."/>
         </Property>
-        <Property Name="MultiFactorAuthEnabled" Type="IBMServiceRoot.IBM">
+        <Property Name="MultiFactorAuthEnabled" Type="Edm.Boolean">
           <Annotation Term="OData.Permissions" EnumMember="OData.Permission/Read"/>
           <Annotation Term="OData.Description" String="An indication of whether multi factor authentication is enabled."/>
           <Annotation Term="OData.LongDescription" String="This property shall indicate if the multi factor authentication is enabled in the system."/>

--- a/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
+++ b/redfish-core/schema/oem/ibm/csdl/OemUpdateService_v1.xml
@@ -13,8 +13,6 @@
   <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService">
       <Annotation Term="Redfish.OwningEntity" String="IBM"/>
-    </Schema>
-    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OemUpdateService.v1_0_0">
       <Action Name="ConcurrentUpdate" IsBound="true">
         <Annotation Term="OData.Description" String="This action concurrently updates firmware."/>
         <Annotation Term="OData.LongDescription" String="This action concurrently updates firmware, synchronizing the host and bmc."/>

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCLogEntry_v1.xml
@@ -26,7 +26,7 @@
         <Annotation Term="OData.AutoExpand"/>
         <Property Name="OpenBMC" Type="OpenBMCLogEntry.v1_0_0.OpenBMC"/>
       </ComplexType>
-      <ComplexType Name="OpenBMC">
+      <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
         <Annotation Term="OData.AutoExpand"/>

--- a/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
+++ b/redfish-core/schema/oem/openbmc/csdl/OpenBMCMessage_v1.xml
@@ -24,9 +24,9 @@
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="OpenBMCMessage Oem properties."/>
         <Annotation Term="OData.AutoExpand"/>
-        <Property Name="OpenBMC" Type="OpenBMCMessage.OpenBMC"/>
+        <Property Name="OpenBMC" Type="OpenBMCMessage.v1_0_0.OpenBMC"/>
       </ComplexType>
-      <ComplexType Name="OpenBMC">
+      <ComplexType Name="OpenBMC" BaseType="Resource.OemObject">
         <Annotation Term="OData.AdditionalProperties" Bool="true"/>
         <Annotation Term="OData.Description" String="Oem properties for OpenBMC."/>
         <Annotation Term="OData.AutoExpand"/>


### PR DESCRIPTION
The Redfish Service Validator 3.1.6 reports new errors that were not caught by earlier versions. The following failures were found and fixed.

- /redfish/v1, /redfish/v1/SessionService/Sessions Oem/IBM/ACFWindowActive, DateTime, DateTimeLocalOffset, Model, MultiFactorAuthEnabled, SerialNumber Property Type Error: Properties are expected to be objects but found primitive types (bool/str). Fixed by correcting the IBMServiceRoot CSDL property types from self-referential IBMServiceRoot.IBM to the correct Edm.Boolean, Edm.String, and Edm.DateTimeOffset types.

- /redfish/v1/Systems/system/PCIeDevices/<str> Links/Oem/IBM/PCIeSlot/@odata.type Required Property Error: The property '@odata.type' is mandatory, but not present in the payload. Fixed by changing PCIeSlot from a Property to a NavigationProperty in IBMPCIeDevice CSDL.

- /redfish/v1/Chassis/chassis/PCIeSlots Slots/<N>/Links/Oem/IBM/AssociatedAssembly/@odata.type Required Property Error: The property '@odata.type' is mandatory, but not present in the payload. Fixed by changing AssociatedAssembly and UpstreamFabricAdapters from Property to NavigationProperty in IBMPCIeSlots CSDL.

- /redfish/v1/LicenseService/Licenses Members/<N> - Reference Object Error: The navigation property 'Members' contains extra properties. Fixed by removing Id and Name from each member entry in license_service.hpp, and moving Members@odata.count outside the loop.

- /redfish/v1/Systems/system/LogServices/<str>/Entries/<str>/OemPelAttachment Unknown Resource Type / @odata.type not present Required Property Error: The property '@odata.type' is mandatory, but not present in the payload. Fixed by populating @odata.type, @odata.id, Name, and Id on the response in log_services.hpp, and adding a top-level EntityType definition to IBMLogEntryAttachment CSDL.

- /redfish/v1/UpdateService Actions/Oem/#OemUpdateService.v1_0_0.ConcurrentUpdate/target Action URI Error: The target URI for the action is expected to be '/redfish/v1/UpdateService/Actions/Oem/OemUpdateService.ConcurrentUpdate'. Fixed by moving the ConcurrentUpdate action into the unversioned OemUpdateService namespace in the CSDL, and updating the action key in update_service.hpp to #OemUpdateService.ConcurrentUpdate.

- /redfish/v1/Systems/system/LogServices/EventLog/Entries/<str> Oem/OpenBMC - Object Type Error: The object 'OpenBMC' contains a value for '@odata.type' that is not valid for type 'Resource.OemObject'. Fixed by adding BaseType="Resource.OemObject" to the OpenBMC complex type in OpenBMCLogEntry and OpenBMCMessage CSDL, and correcting the unversioned type reference in OpenBMCMessage CSDL.

- /redfish/v1/Systems/system/PCIeDevices/<str>/PCIeFunctions Members@odata.count not present. Fixed by correcting the key from PCIeFunctions@odata.count to Members@odata.count in pcie.hpp.

- /redfish/v1/Systems/system Oem/IBM/ChapData/@odata.type not present. Fixed by adding @odata.type "#IBMComputerSystem.v1_0_0.ChapData" to the ChapData object in systems.hpp.

- /redfish/v1/Systems/system Actions/Oem/#IBMComputerSystem.v1_0_0.ExecutePanelFunction/target Action URI Error: The target URI for the action is expected to be '/redfish/v1/Systems/system/Actions/Oem/IBMComputerSystem.v1_0_0.ExecutePanelFunction'. Fixed by changing the action key to #IBMComputerSystem.ExecutePanelFunction and updating the target URI and route to drop the /IBM/ path segment in systems.hpp.

- /redfish/v1/Chassis/chassis/EnvironmentMetrics PowerWatts/@odata.id - Unknown Property Error: The property '@odata.id' is not part of the excerpt usage. Fixed by removing the @odata.id field from the PowerWatts excerpt in environment_metrics.hpp, leaving only DataSourceUri as the reference.

- /redfish/v1/Chassis/chassis/EnvironmentMetrics FanSpeedsPercent DataSourceUri links returning HTTP 404. Fixed by using getSensorId() to build the DataSourceUri with the correct type-prefixed sensor name (e.g. fantach_fan0_0) in environment_metrics.hpp, matching the names served by the Sensors collection.

Additional CSDL schema fixes aligned with the 1120 branch:
  - IBMFabricAdapter: corrected unversioned IBM type reference to IBMFabricAdapter.v1_0_0.IBM
  - IBMManagerAccount: added BaseType="Resource.OemObject" to IBM and ACF complex types

Tested:
- Redfish Service Validator 3.1.6 run passes on those URIs