### PR TITLE
1210: RBMC: Fix Manager.ForceFailover parameter check

### DIFF
--- a/redfish-core/include/manager_redundancy.hpp
+++ b/redfish-core/include/manager_redundancy.hpp
@@ -275,25 +275,33 @@ inline void handleManagerForceFailover(
         messages::resourceNotFound(asyncResp->res, "Manager", managerId);
         return;
     }
-
     BMCWEB_LOG_DEBUG("Post Force Failover");
 
-    std::optional<std::string> newManager;
-
+    std::string newManager;
     if (!json_util::readJsonAction(req, asyncResp->res, "NewManager/@odata.id",
                                    newManager))
     {
         return;
     }
 
+    std::string newManagerId;
     boost::system::result<boost::urls::url> parsedUrl =
-        boost::urls::parse_relative_ref(*newManager);
-    if (crow::utility::readUrlSegments(*parsedUrl, "redfish", "v1", "Managers",
-                                       BMCWEB_REDFISH_MANAGER_URI_NAME))
+        boost::urls::parse_relative_ref(newManager);
+
+    if (!crow::utility::readUrlSegments(*parsedUrl, "redfish", "v1", "Managers",
+                                        std::ref(newManagerId)))
     {
         BMCWEB_LOG_WARNING(
-            "Invalid property value for NewManager/@odata.id: {}", *newManager);
-        messages::actionParameterNotSupported(asyncResp->res, *newManager,
+            "Invalid property value for NewManager/@odata.id: {}", newManager);
+        messages::actionParameterNotSupported(asyncResp->res, newManager,
+                                              "ForceFailover");
+        return;
+    }
+    if (newManagerId != BMCWEB_REDFISH_MANAGER_URI_NAME)
+    {
+        BMCWEB_LOG_WARNING(
+            "Invalid property value for NewManager/@odata.id: {}", newManager);
+        messages::actionParameterNotSupported(asyncResp->res, newManager,
                                               "ForceFailover");
         return;
     }


### PR DESCRIPTION
This fixes the paramter check of Manager.ForceFailover action which does not validate NewManager id properly.

For example, newManager id is not validated.

```
curl -k -H "Content-Type: application/json" \
     -X POST https://${bmc}/redfish/v1/Managers/bmc/Actions/Manager.ForceFailover \
     -d '{ "NewManager": { "@odata.id": "/redfish/v1/Managers/bmcBad" } }'
```

After the fix, this will return an error like

```
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "#Message.v1_1_1.Message",
        "Message": "The parameter /redfish/v1/Managers/bmcBad for the action ForceFailover is not supported on the target resource.",
        "MessageArgs": [
          "/redfish/v1/Managers/bmcBad",
          "ForceFailover"
        ],
        "MessageId": "Base.1.19.ActionParameterNotSupported",
        "MessageSeverity": "Warning",
        "Resolution": "Remove the parameter supplied and resubmit the request if the operation failed."
      }
    ],
    "code": "Base.1.19.ActionParameterNotSupported",
    "message": "The parameter /redfish/v1/Managers/bmcBad for the action ForceFailover is not supported on the target resource."
  }
```