### PR TITLE
dump_offload: prevent connection rejection from terminating active of…

### DIFF
--- a/include/dump_offload.hpp
+++ b/include/dump_offload.hpp
@@ -511,6 +511,12 @@ inline void requestRoutesDumpOffload(App& app)
                 BMCWEB_LOG_DEBUG("No handler to cleanup");
                 return;
             }
+            if (systemHandlers->connection.get() != &conn)
+            {
+                BMCWEB_LOG_DEBUG(
+                    "Close event for non-active connection, ignoring cleanup");
+                return;
+            }
             BMCWEB_LOG_DEBUG("cancelling AsyncOperations");
             // Cancel all async operations to release shared_ptr references
             systemHandlers->cancelAsyncOperations();


### PR DESCRIPTION
…fload

When a dump offload is already in progress, any subsequent offload request is rejected with a "503 Service Unavailable" error and the rejected connection is closed.

However, bmcweb uses a shared static `systemHandlers` pointer, the `.onclose` callback (which is registered for all connections on the dump attachment route) gets triggered when the newly rejected connection is closed. Since `systemHandlers` is not null, the callback would execute the cleanup logic, cancel active async socket reads, remove socket files, and nullify `systemHandlers`. This abruptly terminates the ongoing (first) offload transfer and leaves subsequent attempts wedged.

This commit resolves the issue by verifying if the connection being closed (`conn`) matches the active connection registered in the active handler (`systemHandlers->connection`). If the closed connection is a non-active connection (such as a rejected parallel request), the cleanup logic is skipped and the handler remains active.

Tested:
1. Initiated a non-disruptive system dump offload from ASMI.
2. Attempted a second offload from a new ASMI tab/browser.
3. Verified the second request is gracefully rejected with a 503 Service Unavailable without interrupting the first active offload which continues to completion.
4. Subsequent offloads can be successfully initiated and completed.