### PR TITLE
Ethernet Port: Add LLDP port schema to interfaces

### DIFF
--- a/Redfish.md
+++ b/Redfish.md
@@ -509,6 +509,22 @@ Fields common to all schemas
 - Status
 - UUID
 
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/
+
+#### PortCollection
+
+- Description
+- Members
+- `Members@odata.count`
+
+### /redfish/v1/Managers/bmc/DedicatedNetworkPorts/{DedicatedNetworkPortId}
+
+#### DedicatedNetworkPort
+
+- Ethernet/LLDPEnabled
+- Id
+- Links/EthernetInterfaces
+
 ### /redfish/v1/Managers/bmc/EthernetInterfaces/
 
 #### EthernetInterfaceCollection
@@ -533,6 +549,7 @@ Fields common to all schemas
 - IPv6DefaultGateway
 - IPv6StaticAddresses
 - InterfaceEnabled
+- Links/Ports
 - LinkStatus
 - MACAddress
 - NameServers

--- a/redfish-core/lib/ethernet.hpp
+++ b/redfish-core/lib/ethernet.hpp
@@ -2184,6 +2184,171 @@ inline bool verifyNames(const std::string& parent, const std::string& iface)
     return iface.starts_with(parent + "_");
 }
 
+inline void
+    handleNetworkPortPatch(App& app, const crow::Request& req,
+                           const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                           const std::string& managerId,
+                           const std::string& portId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if (managerId != "bmc")
+    {
+        messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+        return;
+    }
+    std::optional<bool> emitLldp;
+    if (!json_util::readJsonPatch(req, asyncResp->res, "Ethernet/LLDPEnabled",
+                                  emitLldp))
+    {
+        return;
+    }
+    if (emitLldp)
+    {
+        sdbusplus::asio::setProperty(
+            *crow::connections::systemBus, "xyz.openbmc_project.Network",
+            "/xyz/openbmc_project/network/" + portId,
+            "xyz.openbmc_project.Network.EthernetInterface", "EmitLLDP",
+            *emitLldp,
+            [asyncResp](const boost::system::error_code ec,
+                        const sdbusplus::message_t&) {
+            if (ec)
+            {
+                BMCWEB_LOG_ERROR << "D-Bus error setting EmitLLDP: " << ec;
+                messages::internalError(asyncResp->res);
+                return;
+            }
+        });
+    }
+}
+
+inline void
+    handleGetLLDPEnabled(const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& portId,
+                         const boost::system::error_code& ec, bool enabled)
+{
+    if (ec)
+    {
+        if (ec.value() == EBADR)
+        {
+            BMCWEB_LOG_WARNING << "Port " << portId << " Unreachable";
+            messages::resourceNotFound(asyncResp->res, "Port", portId);
+            return;
+        }
+        BMCWEB_LOG_ERROR << "DBus error: " << ec;
+        messages::internalError(asyncResp->res);
+        return;
+    }
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/" + portId;
+    asyncResp->res.jsonValue["@odata.type"] = "#Port.v1_10_0.Port";
+    asyncResp->res.jsonValue["Id"] = portId;
+    asyncResp->res.jsonValue["Name"] = "Manager Dedicated Network Port";
+    asyncResp->res.jsonValue["Ethernet"]["LLDPEnabled"] = enabled;
+    nlohmann::json::array_t ifaceArray;
+
+    nlohmann::json::object_t port;
+    port["@odata.id"] = "/redfish/v1/Managers/bmc/EthernetInterfaces/" + portId;
+    ifaceArray.push_back(std::move(port));
+    asyncResp->res.jsonValue["Links"]["EthernetInterfaces@odata.count"] =
+        ifaceArray.size();
+    asyncResp->res.jsonValue["Links"]["EthernetInterfaces"] =
+        std::move(ifaceArray);
+}
+
+inline void
+    handleNetworkPortGet(App& app, const crow::Request& req,
+                         const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+                         const std::string& managerId,
+                         const std::string& portId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+    if (managerId != "bmc")
+    {
+        messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+        return;
+    }
+    sdbusplus::asio::getProperty<bool>(
+        *crow::connections::systemBus, "xyz.openbmc_project.Network",
+        "/xyz/openbmc_project/network/" + portId,
+        "xyz.openbmc_project.Network.EthernetInterface", "EmitLLDP",
+        [asyncResp, portId](const boost::system::error_code ec,
+                            const bool val) {
+        handleGetLLDPEnabled(asyncResp, portId, ec, val);
+    });
+}
+
+inline void fillDedicatedNetworkPort(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp, bool success,
+    const boost::container::flat_set<std::string>& ifaceList)
+{
+    if (!success)
+    {
+        messages::internalError(asyncResp->res);
+        BMCWEB_LOG_ERROR << "Failed to fetch the list of network ports";
+        return;
+    }
+
+    asyncResp->res.jsonValue["@odata.type"] = "#PortCollection.PortCollection";
+    asyncResp->res.jsonValue["@odata.id"] =
+        "/redfish/v1/Managers/bmc/DedicatedNetworkPorts";
+    asyncResp->res.jsonValue["Name"] = "Port Collection";
+
+    nlohmann::json::array_t ifaceArray;
+    for (const std::string& ifaceItem : ifaceList)
+    {
+        nlohmann::json::object_t iface;
+        iface["@odata.id"] = "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/" +
+                             ifaceItem;
+        ifaceArray.push_back(std::move(iface));
+    }
+
+    asyncResp->res.jsonValue["Members@odata.count"] = ifaceArray.size();
+    asyncResp->res.jsonValue["Members"] = std::move(ifaceArray);
+}
+
+inline void populateDedicatedPortsRoutes(
+    App& app, const crow::Request& req,
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& managerId)
+{
+    if (!redfish::setUpRedfishRoute(app, req, asyncResp))
+    {
+        return;
+    }
+
+    if (managerId != "bmc")
+    {
+        messages::resourceNotFound(asyncResp->res, "Manager", managerId);
+        return;
+    }
+
+    getEthernetIfaceList(
+        [asyncResp](const bool& success,
+                    const boost::container::flat_set<std::string>& ifaceList) {
+        fillDedicatedNetworkPort(asyncResp, success, ifaceList);
+    });
+}
+
+inline void populateConnectedPortLink(
+    const std::shared_ptr<bmcweb::AsyncResp>& asyncResp,
+    const std::string& portId)
+{
+    nlohmann::json::array_t ifaceArray;
+
+    nlohmann::json::object_t port;
+    port["@odata.id"] = "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/" +
+                        portId;
+    ifaceArray.push_back(std::move(port));
+    asyncResp->res.jsonValue["Links"]["Ports@odata.count"] = ifaceArray.size();
+    asyncResp->res.jsonValue["Links"]["Ports"] = std::move(ifaceArray);
+}
+
 inline void requestEthernetInterfacesRoutes(App& app)
 {
     BMCWEB_ROUTE(app, "/redfish/v1/Managers/bmc/EthernetInterfaces/")
@@ -2272,6 +2437,7 @@ inline void requestEthernetInterfacesRoutes(App& app)
             asyncResp->res.jsonValue["Description"] =
                 "Management Network Interface";
 
+            populateConnectedPortLink(asyncResp, ifaceId);
             parseInterfaceData(asyncResp, ifaceId, ethData, ipv4Data, ipv6Data,
                                ipv6GatewayData);
         });
@@ -2459,6 +2625,18 @@ inline void requestEthernetInterfacesRoutes(App& app)
             }
         });
     });
+    BMCWEB_ROUTE(app, "/redfish/v1/Managers/<str>/DedicatedNetworkPorts/<str>/")
+        .privileges(redfish::privileges::patchEthernetInterface)
+        .methods(boost::beast::http::verb::patch)(
+            std::bind_front(handleNetworkPortPatch, std::ref(app)));
+    BMCWEB_ROUTE(app, "/redfish/v1/Managers/<str>/DedicatedNetworkPorts/<str>/")
+        .privileges(redfish::privileges::getEthernetInterface)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(handleNetworkPortGet, std::ref(app)));
+    BMCWEB_ROUTE(app, "/redfish/v1/Managers/<str>/DedicatedNetworkPorts/")
+        .privileges(redfish::privileges::getEthernetInterfaceCollection)
+        .methods(boost::beast::http::verb::get)(
+            std::bind_front(populateDedicatedPortsRoutes, std::ref(app)));
 }
 
 } // namespace redfish

--- a/scripts/parse_registries.py
+++ b/scripts/parse_registries.py
@@ -19,10 +19,7 @@ WARNING = """/****************************************************************
  * github organization.
  ***************************************************************/"""
 
-REGISTRY_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+REGISTRY_HEADER = PRAGMA_ONCE + WARNING + """
 #include "registries.hpp"
 
 #include <array>
@@ -32,7 +29,6 @@ REGISTRY_HEADER = (
 namespace redfish::registries::{}
 {{
 """
-)
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -173,10 +169,7 @@ def create_Subordinate_Overrides(target_list):
     return target_list_create
 
 
-PRIVILEGE_HEADER = (
-    PRAGMA_ONCE
-    + WARNING
-    + """
+PRIVILEGE_HEADER = PRAGMA_ONCE + WARNING + """
 #include "privileges.hpp"
 
 #include <array>
@@ -186,7 +179,6 @@ PRIVILEGE_HEADER = (
 namespace redfish::privileges
 {
 """
-)
 
 
 def make_privilege_registry():


### PR DESCRIPTION
gerrit link:https://gerrit.openbmc.org/c/openbmc/bmcweb/+/76569
Link Layer Discovery Protocol is a Data Link Layer protocol used for discovering devices on a local network. LLDP advertises information about themselves to directly connected devices. This information includes the device's identity, capabilities, and network management information, which can be used for network monitoring, topology discovery and network troubleshooting.

This commit will add Bmcweb changes required to enable/disable LLDP property in ethernet interfaces.

Schema:
https://redfish.dmtf.org/schemas/v1/PortCollection.json https://redfish.dmtf.org/schemas/v1/Port.v1_14_0.json

Redfish validator successfully executed for the changes.

Tested by
Get/Patch on
curl https://xxx/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1

{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1", "@odata.type": "#Port.v1_14_0.Port",
"Ethernet": {
"LLDPEnabled": false
},
"Id": "eth1",
"Links": {
"EthernetInterfaces": [
{
"@odata.id": "/redfish/v1/Managers/bmc/EthernetInterfaces/eth1" }
]
},
"Name": "Manager Dedicated Network Port"
}

Get on
curl https://xxx/redfish/v1/Managers/bmc/EthernetInterfaces {
...
"Links": {
"Ports": [
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1" }
],
"Ports@odata.count": 1
}
...
}
Get on
curl https://xxx/redfish/v1/Managers/bmc/DedicatedNetworkPorts

{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts", "@odata.type": "#PortCollection.PortCollection",
"Members": [
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth0" },
{
"@odata.id": "/redfish/v1/Managers/bmc/DedicatedNetworkPorts/eth1" }
],
"Members@odata.count": 2,
"Name": "Port Collection"
}

Change-Id: I84b49b043bfa83489e26ffe75754e830bd92d8f0